### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ repository.
 
 Start the hotspot service on startup (using your saved configuration) with:
 
-    systemctl enable create-ap
+    systemctl enable create_ap
 
 ### Tested with Ubuntu from 16.04 to 20.04. If any issue is found, file an issue on github.
 


### PR DESCRIPTION
systemctl command had a typing error. The name of the service file is "create_ap.service" instead of "create-ap.service"