### PR TITLE
Remove the mention of yay in the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,7 @@ sudo apt install linux-wifi-hotspot
 
 #### Arch based distributions
 
-Install with:
-
-```bash
-yay -S linux-wifi-hotspot
-```
+Linux Wifi Hotspot is available as a package on the [AUR](https://aur.archlinux.org/packages/linux-wifi-hotspot/).
 
 ### Dependencies
 


### PR DESCRIPTION
`yay` is an unofficial AUR helper and is thus not supported by Arch Linux.
I changed it to just mention and link to the AUR package instead, users should be able to install the package from there.