### PR TITLE
Always fallback if multiple channels are not supproted

### DIFF
--- a/src/scripts/create_ap
+++ b/src/scripts/create_ap
@@ -1573,32 +1573,38 @@ if [[ $NO_VIRT -eq 0 ]]; then
         echo "DONE"
     fi
 
+    # Find interface frequency and channel
+    WIFI_IFACE_FREQ=$(iw dev ${WIFI_IFACE} link | grep -i freq | awk '{print $2}')
+    WIFI_IFACE_CHANNEL=$(ieee80211_frequency_to_channel ${WIFI_IFACE_FREQ})
+    echo -n "${WIFI_IFACE} is already associated with channel ${WIFI_IFACE_CHANNEL} (${WIFI_IFACE_FREQ} MHz)"
 
+
+    # If the frequency is not explicitly set, set one automatically
     if is_wifi_connected ${WIFI_IFACE} && [[ $FREQ_BAND_SET -eq 0 ]]; then
-        WIFI_IFACE_FREQ=$(iw dev ${WIFI_IFACE} link | grep -i freq | awk '{print $2}')
-        WIFI_IFACE_CHANNEL=$(ieee80211_frequency_to_channel ${WIFI_IFACE_FREQ})
-        echo -n "${WIFI_IFACE} is already associated with channel ${WIFI_IFACE_CHANNEL} (${WIFI_IFACE_FREQ} MHz)"
         if is_5ghz_frequency $WIFI_IFACE_FREQ; then
             FREQ_BAND=5
         else
             FREQ_BAND=2.4
         fi
-        if [[ $WIFI_IFACE_CHANNEL -ne $CHANNEL ]]; then
-            if ( get_adapter_info ${IFACE} | grep "#channels <= 2" -q )
-            then
-                echo -e "\nmultiple channels supported"
-            else
-                echo -e  "\nmultiple channels not supported",
-                echo -e  "\nfallback to channel ${WIFI_IFACE_CHANNEL}"
-                CHANNEL=$WIFI_IFACE_CHANNEL
-            fi
-        else
-            echo "channel------------------ ${CHANNEL}"
-        fi
     elif is_wifi_connected ${WIFI_IFACE} && [[ $FREQ_BAND_SET -eq 1 ]]; then
         echo "Custom frequency band set with ${FREQ_BAND}Mhz with channel ${CHANNEL}"
     fi
 
+    # If the access point channel is the same as the interface channel, do:
+    # - Make sure that the adapter support multiple channels
+    # - Otherwise fallback to the same interface channel
+    if [[ $WIFI_IFACE_CHANNEL -ne $CHANNEL ]]; then
+        if ( get_adapter_info ${IFACE} | grep "#channels <= 2" -q )
+        then
+            echo -e "\nmultiple channels supported"
+        else
+            echo -e  "\nmultiple channels not supported",
+            echo -e  "\nfallback to channel ${WIFI_IFACE_CHANNEL}"
+            CHANNEL=$WIFI_IFACE_CHANNEL
+        fi
+    else
+        echo "channel------------------ ${CHANNEL}"
+    fi
 
     VIRTDIEMSG="Maybe your WiFi adapter does not fully support virtual interfaces.
        Try again with --no-virt."


### PR DESCRIPTION
Currently if a user select the same interface for wifi and internet, and his adapter doesn't support multiple channels , this program will fail with a cryptic error.

create_ap can fallback to the wifi channel automatically but this is path is not taken because of this check `[[ $FREQ_BAND_SET -eq 0 ]]` (`-freq-band` is always passed to create_ap).

This pr extracts the fallback out of that branch, so now it always fallbacks if multiple channels are not supported even if the frequency is explicitly set.