### PR TITLE
Fix config file path in Debian packaging

### DIFF
--- a/debian/linux-wifi-hotspot.install
+++ b/debian/linux-wifi-hotspot.install
@@ -1,1 +1,1 @@
-src/scripts/create_ap.conf etc/*
+src/scripts/create_ap.conf etc/


### PR DESCRIPTION
With the *, config is installed in a subdirectory named *:
```
$ dpkg -L linux-wifi-hotspot 
/.
/etc
/etc/*
/etc/*/create_ap.conf
```