### PR TITLE
fix: frequency band in config ignored

### DIFF
--- a/src/scripts/create_ap
+++ b/src/scripts/create_ap
@@ -1048,6 +1048,11 @@ ARGS=( "$@" )
 
 FREQ_BAND_SET=0
 
+# we need to set FREQ_BAND_SET when specifying FREQ_BAND via config file, otherwise the option is ignored.
+if [ "$FREQ_BAND" != "" ]; then
+    FREQ_BAND_SET=1
+fi
+
 # Preprocessing for --config before option-parsing starts
 for ((i=0; i<$#; i++)); do
     if [[ "${ARGS[i]}" = "--config" ]]; then


### PR DESCRIPTION
When `FREQ_BAND` is set in the config file it's being ignored because `FREQ_BAND_SET` is 0. This checks whether or not `FREQ_BAND` is set and sets `FREQ_BAND_SET` according to it.

<details>

<summary>Log output without fix:</summary>

```
# sudo create_ap --config /etc/create_ap.conf
WARN: Unrecognized configuration entry #CHANNEL
Config dir: /tmp/create_ap.wlp7s0.conf.Ty48EI66
PID: 172965
Network Manager found, set ap0 as unmanaged device... DONE
wlp7s0 is already associated with channel 44 (5220 MHz)
multiple channels supported
Creating a virtual WiFi interface... ap0 created.

ERROR: Your adapter can not transmit to channel 1, frequency band 5GHz.


Doing cleanup.. done
```

</details>

<details>

<summary>Log output after fix:</summary>

```
# sudo create_ap --config /etc/create_ap.conf
WARN: Unrecognized configuration entry #CHANNEL
Config dir: /tmp/create_ap.wlp7s0.conf.1ISeCrna
PID: 173646
Network Manager found, set ap0 as unmanaged device... DONE
Custom frequency band set with 2.4Mhz with channel 1
Creating a virtual WiFi interface... ap0 created.
Sharing Internet using method: nat
hostapd command-line interface: hostapd_cli -p /tmp/create_ap.wlp7s0.conf.1ISeCrna/hostapd_ctrl
ap0: interface state UNINITIALIZED->COUNTRY_UPDATE
Low entropy detected, starting haveged
haveged: command socket is listening at fd 4
ap0: interface state COUNTRY_UPDATE->HT_SCAN
20/40 MHz operation not permitted on channel pri=1 sec=5 based on overlapping BSSes
Fallback to 20 MHz
ap0: interface state HT_SCAN->ENABLED
ap0: AP-ENABLED 
^Cap0: interface state ENABLED->DISABLED
ap0: AP-DISABLED 
ap0: CTRL-EVENT-TERMINATING 

nl80211: deinit ifname=ap0 disabled_11b_rates=0
Doing cleanup.. done
```

</details>

<details>

<summary>Config file used for testing:</summary>

```
#CHANNEL=default
GATEWAY=192.168.12.1
WPA_VERSION=2
ETC_HOSTS=0
DHCP_DNS=gateway
NO_DNS=1
NO_DNSMASQ=0
HIDDEN=0
MAC_FILTER=0
MAC_FILTER_ACCEPT=/etc/hostapd/hostapd.accept
ISOLATE_CLIENTS=0
SHARE_METHOD=nat
IEEE80211N=1
IEEE80211AC=1
HT_CAPAB=[HT40+]
VHT_CAPAB=
DRIVER=nl80211
NO_VIRT=0
COUNTRY=DE
FREQ_BAND=2.4
NEW_MACADDR=
DAEMONIZE=0
DAEMON_PIDFILE=
DAEMON_LOGFILE=/dev/null
NO_HAVEGED=0
WIFI_IFACE=<interface>
INTERNET_IFACE=<interface>
SSID=<ssid>
PASSPHRASE=<password>
USE_PSK=0
```

</details>