### PR TITLE
Use 'aa-complain' instead of 'complain' to remove dnsmasq restriction

### DIFF
--- a/src/scripts/create_ap
+++ b/src/scripts/create_ap
@@ -1884,7 +1884,7 @@ if [[ "$SHARE_METHOD" != "bridge" ]]; then
       # remove restriction.
 
       if COMPLAIN_CMD=$(command -v complain || command -v aa-complain); then
-        COMPLAIN_CMD dnsmasq
+        $COMPLAIN_CMD dnsmasq
       fi
 
       umask 0033

--- a/src/scripts/create_ap
+++ b/src/scripts/create_ap
@@ -1879,10 +1879,12 @@ if [[ "$SHARE_METHOD" != "bridge" ]]; then
     if [[ $NO_DNSMASQ -eq 0 ]]; then
       iptables -w -I INPUT -p udp -m udp --dport 67 -j ACCEPT || die
 
-      if which aa-complain > /dev/null 2>&1; then
-          # openSUSE's apparmor does not allow dnsmasq to read files.
-          # remove restriction.
-          aa-complain dnsmasq
+
+      # apparmor does not allow dnsmasq to read files.
+      # remove restriction.
+
+      if COMPLAIN_CMD=$(command -v complain || command -v aa-complain); then
+        COMPLAIN_CMD dnsmasq
       fi
 
       umask 0033

--- a/src/scripts/create_ap
+++ b/src/scripts/create_ap
@@ -1879,10 +1879,10 @@ if [[ "$SHARE_METHOD" != "bridge" ]]; then
     if [[ $NO_DNSMASQ -eq 0 ]]; then
       iptables -w -I INPUT -p udp -m udp --dport 67 -j ACCEPT || die
 
-      if which complain > /dev/null 2>&1; then
+      if which aa-complain > /dev/null 2>&1; then
           # openSUSE's apparmor does not allow dnsmasq to read files.
           # remove restriction.
-          complain dnsmasq
+          aa-complain dnsmasq
       fi
 
       umask 0033


### PR DESCRIPTION
Using the default installation from the AUR, I ran into the following error when trying to create a hotspot:

`dnsmasq: cannot read /tmp/create_ap.wlp18s0.conf.fgQTo8iD/dnsmasq.conf: Permission denied`

This looks like it's related related to an old issue with create_ap discussed [here](https://github.com/oblique/create_ap/issues/103), where @mehdisadeghi has found a solution, although it seems it hasn't been implemented.

Seems like `complain` is being used to remove restrictions on dmsmasq, although the command is supposed to be `aa-complain`. At least, this has been the case when testing on my system (Manjaro) as well as on Arch according to that thread.

From the OpenSUSE docs, it looks like aa-complain is the correct command on OpenSUSE distros as well, so I think it makes sense to make this change: https://doc.opensuse.org/documentation/leap/security/html/book-security/cha-apparmor-commandline.html

I imagine this requires a bit more testing though.