### PR TITLE
Fix clean-up of unmanaged devices in NetworkManager.conf

### DIFF
--- a/src/scripts/create_ap
+++ b/src/scripts/create_ap
@@ -509,7 +509,7 @@ networkmanager_add_unmanaged() {
     fi
 
     mutex_lock
-    UNMANAGED=$(grep -m1 -Eo '^unmanaged-devices=[[:alnum:]:;,-]*' /etc/NetworkManager/NetworkManager.conf)
+    UNMANAGED=$(grep -m1 -Eo '^unmanaged-devices=[[:alnum:]:;,?*~=-]*' /etc/NetworkManager/NetworkManager.conf)
 
     WAS_EMPTY=0
     [[ -z "$UNMANAGED" ]] && WAS_EMPTY=1
@@ -566,7 +566,7 @@ networkmanager_rm_unmanaged() {
     fi
 
     mutex_lock
-    UNMANAGED=$(grep -m1 -Eo '^unmanaged-devices=[[:alnum:]:;,-]*' /etc/NetworkManager/NetworkManager.conf | sed 's/unmanaged-devices=//' | tr ';,' ' ')
+    UNMANAGED=$(grep -m1 -Eo '^unmanaged-devices=[[:alnum:]:;,?*~=-]*' /etc/NetworkManager/NetworkManager.conf | sed 's/unmanaged-devices=//' | tr ';,' ' ')
 
     if [[ -z "$UNMANAGED" ]]; then
         mutex_unlock


### PR DESCRIPTION
The clean-up routine did not account for some characters that the `unmanaged-devices` option in `NetworkManager.conf` can contain, such as globbing characters. Because of this, the existing value of `unmanaged-devices` was not restored correctly. For example, the following:

```
unmanaged-devices=interface-name:docker?;interface-name:br-????????????
```

would get truncated to:
```
unmanaged-devices=interface-name:docker
```

See https://man.archlinux.org/man/NetworkManager.conf.5.en#Device_List_Format for mentions of these additional characters.