### PR TITLE
[SECURITY] remove insecure TKIP from configurations

### DIFF
--- a/src/scripts/create_ap
+++ b/src/scripts/create_ap
@@ -1722,7 +1722,7 @@ if [[ -n "$PASSPHRASE" ]]; then
 wpa=${WPA_VERSION}
 wpa_${WPA_KEY_TYPE}=${PASSPHRASE}
 wpa_key_mgmt=WPA-PSK
-wpa_pairwise=TKIP CCMP
+wpa_pairwise=CCMP
 rsn_pairwise=CCMP
 EOF
 fi


### PR DESCRIPTION
This removes TKIP from the configuration in favor of just CCMP. It is considered insecure and was [deprecated in 2009](https://mentor.ieee.org/802.11/file/08/11-08-1127-12-000m-tgmb-issues-list.xls). Also see [hostapd/defconfig](https://w1.fi/cgit/hostap/tree/hostapd/defconfig?h=hostap_2_10#n393):

> TKIP is an old cryptographic data confidentiality algorithm that is not considered secure. It should not be used anymore. For now, the default hostapd build includes this to allow mixed mode WPA+WPA2 networks to be enabled, but that functionality is subject to be removed in the future.