### PR TITLE
Update frequency parsing for iw 6.7 compatibility

### DIFF
--- a/src/scripts/create_ap
+++ b/src/scripts/create_ap
@@ -342,15 +342,21 @@ ieee80211_frequency_to_channel() {
     local FREQ_MAYBE_FRACTIONAL=$1
     local FREQ=${FREQ_MAYBE_FRACTIONAL%.*}
 
-    if [[ $FREQ -eq 2484 ]]; then
+    if [[ $FREQ -lt 1000 ]]; then
+        echo 0
+    elif [[ $FREQ -eq 2484 ]]; then
         echo 14
+    elif [[ $FREQ -eq 5935 ]]; then
+        echo 2
     elif [[ $FREQ -lt 2484 ]]; then
         echo $(( ($FREQ - 2407) / 5 ))
     elif [[ $FREQ -ge 4910 && $FREQ -le 4980 ]]; then
         echo $(( ($FREQ - 4000) / 5 ))
-    elif [[ $FREQ -le 45000 ]]; then
+    elif [[ $FREQ -lt 5950 ]]; then
         echo $(( ($FREQ - 5000) / 5 ))
-    elif [[ $FREQ -ge 58320 && $FREQ -le 64800 ]]; then
+    elif [[ $FREQ -le 45000 ]]; then
+        echo $(( ($FREQ - 5950) / 5 ))
+    elif [[ $FREQ -ge 58320 && $FREQ -le 70200 ]]; then
         echo $(( ($FREQ - 56160) / 2160 ))
     else
         echo 0

--- a/src/scripts/create_ap
+++ b/src/scripts/create_ap
@@ -1595,7 +1595,7 @@ if [[ $NO_VIRT -eq 0 ]]; then
     if is_wifi_connected ${WIFI_IFACE} && [[ $FREQ_BAND_SET -eq 0 ]]; then
         WIFI_IFACE_FREQ=$(iw dev ${WIFI_IFACE} link | grep -i freq | awk '{print $2}')
         WIFI_IFACE_CHANNEL=$(ieee80211_frequency_to_channel ${WIFI_IFACE_FREQ})
-        echo -n "${WIFI_IFACE} is already associated with channel ${WIFI_IFACE_CHANNEL} (${WIFI_IFACE_FREQ} GHz)"
+        echo -n "${WIFI_IFACE} is already associated with channel ${WIFI_IFACE_CHANNEL} (${WIFI_IFACE_FREQ} MHz)"
         if is_5ghz_frequency $WIFI_IFACE_FREQ; then
             FREQ_BAND=5
         else

--- a/src/scripts/create_ap
+++ b/src/scripts/create_ap
@@ -321,9 +321,9 @@ can_transmit_to_channel() {
 
     if [[ $USE_IWCONFIG -eq 0 ]]; then
         if [[ $FREQ_BAND == 2.4 ]]; then
-            CHANNEL_INFO=$(get_adapter_info ${IFACE} | grep " 24[0-9][0-9] MHz \[${CHANNEL_NUM}\]")
+            CHANNEL_INFO=$(get_adapter_info ${IFACE} | grep " 24[0-9][0-9]\(\.0\+\)\? MHz \[${CHANNEL_NUM}\]")
         else
-            CHANNEL_INFO=$(get_adapter_info ${IFACE} | grep " \(49[0-9][0-9]\|5[0-9]\{3\}\) MHz \[${CHANNEL_NUM}\]")
+            CHANNEL_INFO=$(get_adapter_info ${IFACE} | grep " \(49[0-9][0-9]\|5[0-9]\{3\}\)\(\.0\+\)\? MHz \[${CHANNEL_NUM}\]")
         fi
         [[ -z "${CHANNEL_INFO}" ]] && return 1
         [[ "${CHANNEL_INFO}" == *no\ IR* ]] && return 1
@@ -339,7 +339,9 @@ can_transmit_to_channel() {
 
 # taken from iw/util.c
 ieee80211_frequency_to_channel() {
-    local FREQ=$1
+    local FREQ_MAYBE_FRACTIONAL=$1
+    local FREQ=${FREQ_MAYBE_FRACTIONAL%.*}
+
     if [[ $FREQ -eq 2484 ]]; then
         echo 14
     elif [[ $FREQ -lt 2484 ]]; then
@@ -356,7 +358,7 @@ ieee80211_frequency_to_channel() {
 }
 
 is_5ghz_frequency() {
-    [[ $1 =~ ^(49[0-9]{2})|(5[0-9]{3})$ ]]
+    [[ $1 =~ ^(49[0-9]{2})|(5[0-9]{3})(\.0+)?$ ]]
 }
 
 is_wifi_connected() {


### PR DESCRIPTION
Since iw 6.7, which adds 802.11ah support, iw may print fractional frequencies (e.g. 917.4 MHz). The change in the formatting code can also affect frequencies in the 2.4 and 5 GHz bands, so a frequency that used to be shown as "2412 MHz" may now be shown as "2412.0 MHz".

This breaks the parsing logic in `can_transmit_to_channel`, `ieee80211_frequency_to_channel` and `is_5ghz_frequency`.

The problem in `can_transmit_to_channel` causes an error when creating an AP, due the frequency not being detected as supported ("ERROR: Your adapter can not transmit to channel 1, frequency band 2.4GHz.").

Fix this by changing the parsing logic to accept a trailing ".0" (or even ".00", etc.) suffix for the existing 2.4 and 5 GHz bands.

See also:
* https://git.kernel.org/pub/scm/linux/kernel/git/jberg/iw.git/commit/?id=f2d9f5b52677f5414dc194be94b5916d2b080eab
* https://git.kernel.org/pub/scm/linux/kernel/git/jberg/iw.git/commit/?id=e2224c729840cc33c6ea89ba5e91b69f79c88e85
* https://git.kernel.org/pub/scm/linux/kernel/git/jberg/iw.git/commit/?id=1bc6ab0abbb6f26f35d826d166d06bc28ae47b6b

The PR also syncs the definition of `ieee80211_frequency_to_channel` with the latest iw release and fixes a minor mistake in a text message.