### PR TITLE
Set program name to fix wayland icon issue

### DIFF
--- a/src/ui/main.c
+++ b/src/ui/main.c
@@ -30,7 +30,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 int main(int argc, char *argv[]) {
 
-
+    g_set_prgname("wihotspot");
     initUi(argc,argv);
 
     return 0;


### PR DESCRIPTION
When running app under Wayland, the icon in the upper left corner of window is missing.
Set the program name to fix the missing icon.

![Screenshot_20240619_235203](https://github.com/lakinduakash/linux-wifi-hotspot/assets/71180087/9fc87c83-ba50-42a9-8536-8fd5808c4606)
