### PR TITLE
SECURITY: Prevent create_ap's --mkconfig switch from overwriting any file without explicit authorization

### DIFF
--- a/src/scripts/create_ap
+++ b/src/scripts/create_ap
@@ -1000,7 +1000,26 @@ send_stop() {
 write_config() {
     local i=1
 
-    if ! eval 'echo -n > "$STORE_CONFIG"' > /dev/null 2>&1; then
+    # If using pkexec, evaluate permissions before writing.
+    #   However, the /etc/create_ap.conf
+    #   location is excepted.
+    if [[ "$STORE_CONFIG" != "/etc/create_ap.conf" && $PKEXEC_UID ]]; then
+        if [ -e "$STORE_CONFIG" ]; then
+            if ! pkexec --user "$(id -nu $PKEXEC_UID)" test -w "$STORE_CONFIG"; then
+                echo "ERROR: 1 $(id -nu $PKEXEC_UID) has insufficient permissions to write to config file $STORE_CONFIG"
+                exit 1
+            fi
+        elif ! pkexec --user "$(id -nu $PKEXEC_UID)" test -w "$(dirname "$STORE_CONFIG")"; then
+            echo "ERROR: 2 $(id -nu $PKEXEC_UID) has insufficient permissions to write to config file $STORE_CONFIG"
+            exit 1
+        fi
+        # Assume that the user is making a conf file in a directory they normally
+        # have control over, and keep permissions strictly private. (i.e. they will
+        # need to run create_ap directly with sudo in order to write to, say, /etc/create_ap2.conf)
+        touch "$STORE_CONFIG"
+        chown "$(id -nu $PKEXEC_UID):$(id -ng $PKEXEC_GID)" "$STORE_CONFIG"
+        chmod 600 "$STORE_CONFIG"
+    elif ! eval 'echo -n > "$STORE_CONFIG"' > /dev/null 2>&1; then
         echo "ERROR: Unable to create config file $STORE_CONFIG" >&2
         exit 1
     fi


### PR DESCRIPTION
This commit allows the `pkexec` caller (i.e. some user) to only write configs to places they normally own, as *well* as /etc/create_ap.conf.

See the following for a deeper description of the file write security issue:

---

**Describe the bug**
Using `pkexec`, create_ap's `--mkconfig` switch can write a file anywhere on the system, given:
- The user is part of the "sudo" or "wheel" group (as outlined in `src/scripts/policies/polkit.rules`)
- The file is not a directory. (Instead, `ERROR: Unable to create config file /some/file` will be returned; technically, this can be used for exploring directory names anyway.)

Use of the switch cannot write *arbitrary* text, only a typical create_ap.conf file output (the `a=b c=d`  key-value pairs). However, this still means any file on the file system can be *overwritten*, allowing a nonprivileged user, to, for example, completely demolish `/etc/apparmor`, or replace the `bash` and `sh` binaries.

**To Reproduce**
Steps to reproduce the behavior:
```bash
$ pkexec --user root create_ap \
  wlan0 wlan0 "somessid" "somepassword" \
  --mkconfig /root/compromised
  # of course, you can try /usr/bin/chmod instead
```

**Expected behavior**
I expected `/root/compromised` to be unwritable without authorization, even if the user is a sudoer (e.g. in the wheel group). Optimally, only `/etc/create_ap.conf` or locations owned by the current user should be writable.

**Screenshots**
N/A

**Desktop (please complete the following information):**
 - OS: Arch Linux x86_64
 - Version: N/A

**Additional context**

I am in the wheel group.

```bash
$ groups
users audio wheel swomf
```