### PR TITLE
Makiing a fix for a root file read vulnerability.

### DIFF
--- a/src/scripts/create_ap
+++ b/src/scripts/create_ap
@@ -1075,7 +1075,7 @@ read_config() {
         if is_config_opt "$opt_name" ; then
             eval $opt_name="\$opt_val"
         else
-            echo "WARN: Unrecognized configuration entry $opt_name" >&2
+            echo "WARN: Unrecognized configuration entry. Please check your config file." >&2
         fi
     done < "$LOAD_CONFIG"
 }


### PR DESCRIPTION
Due to the create_ap script printing any config lines with invalid values, an attacker could run `pkexec create_ap --config /etc/shadow` to retrieve the password hashes for all system users.