### PR TITLE
feat: attempt to use channel of $WIFI_IFACE if setting fails

### DIFF
--- a/src/scripts/create_ap
+++ b/src/scripts/create_ap
@@ -337,7 +337,7 @@ can_transmit_to_channel() {
             [[ $CHANNEL_NUM -eq $WIFI_IFACE_CHANNEL ]] && return 1
 
             # Attempt to use the channel of the interface
-            echo "Unable to transmit using channel $CHANNEL_NUM. Attempting $WIFI_IFACE_CHANNEL."
+            echo "Unable to transmit using channel $CHANNEL_NUM. Attempting $WIFI_IFACE_CHANNEL." >&2
             CHANNEL=$WIFI_IFACE_CHANNEL
             [[ $( ! can_transmit_to_channel "$IFACE" "$CHANNEL") ]] && return 1
         fi
@@ -350,7 +350,7 @@ can_transmit_to_channel() {
             [[ $CHANNEL_NUM -eq $WIFI_IFACE_CHANNEL ]] && return 1
 
             # Attempt to use the channel of the interface
-            echo "Unable to transmit using channel $CHANNEL_NUM. Attempting $WIFI_IFACE_CHANNEL."
+            echo "Unable to transmit using channel $CHANNEL_NUM. Attempting $WIFI_IFACE_CHANNEL." >&2
             CHANNEL=$WIFI_IFACE_CHANNEL
             [[ $( ! can_transmit_to_channel "$IFACE" "$CHANNEL") ]] && return 1
         fi

--- a/src/scripts/create_ap
+++ b/src/scripts/create_ap
@@ -332,14 +332,30 @@ can_transmit_to_channel() {
         else
             CHANNEL_INFO=$(get_adapter_info ${IFACE} | grep " \(49[0-9][0-9]\|5[0-9]\{3\}\)\(\.0\+\)\? MHz \[${CHANNEL_NUM}\]")
         fi
-        [[ -z "${CHANNEL_INFO}" ]] && return 1
-        [[ "${CHANNEL_INFO}" == *no\ IR* ]] && return 1
-        [[ "${CHANNEL_INFO}" == *disabled* ]] && return 1
+
+        if [[ -z "${CHANNEL_INFO}" || "${CHANNEL_INFO}" == *no\ IR* || "${CHANNEL_INFO}" == *disabled* ]]; then
+            [[ $CHANNEL_NUM -eq $WIFI_IFACE_CHANNEL ]] && return 1
+
+            # Attempt to use the channel of the interface
+            echo "Unable to transmit using channel $CHANNEL_NUM. Attempting $WIFI_IFACE_CHANNEL."
+            CHANNEL=$WIFI_IFACE_CHANNEL
+            [[ $( ! can_transmit_to_channel "$IFACE" "$CHANNEL") ]] && return 1
+        fi
         return 0
+
     else
         CHANNEL_NUM=$(printf '%02d' ${CHANNEL_NUM})
         CHANNEL_INFO=$(iwlist ${IFACE} channel | grep -E "Channel[[:blank:]]${CHANNEL_NUM}[[:blank:]]?:")
-        [[ -z "${CHANNEL_INFO}" ]] && return 1
+        if [[ -z "${CHANNEL_INFO}" ]]; then
+            [[ $CHANNEL_NUM -eq $WIFI_IFACE_CHANNEL ]] && return 1
+
+            # Attempt to use the channel of the interface
+            echo "Unable to transmit using channel $CHANNEL_NUM. Attempting $WIFI_IFACE_CHANNEL."
+            CHANNEL=$WIFI_IFACE_CHANNEL
+            [[ $( ! can_transmit_to_channel "$IFACE" "$CHANNEL") ]] && return 1
+        fi
+
+
         return 0
     fi
 }

--- a/src/scripts/create_ap
+++ b/src/scripts/create_ap
@@ -334,7 +334,9 @@ can_transmit_to_channel() {
         fi
 
         if [[ -z "${CHANNEL_INFO}" || "${CHANNEL_INFO}" == *no\ IR* || "${CHANNEL_INFO}" == *disabled* ]]; then
-            [[ $CHANNEL_NUM -eq $WIFI_IFACE_CHANNEL ]] && return 1
+            if (! $USING_DEFAULT_CHANNEL) || [[ $CHANNEL_NUM -eq $WIFI_IFACE_CHANNEL ]]; then
+                return 1
+            fi
 
             # Attempt to use the channel of the interface
             echo "Unable to transmit using channel $CHANNEL_NUM. Attempting $WIFI_IFACE_CHANNEL." >&2
@@ -347,7 +349,9 @@ can_transmit_to_channel() {
         CHANNEL_NUM=$(printf '%02d' ${CHANNEL_NUM})
         CHANNEL_INFO=$(iwlist ${IFACE} channel | grep -E "Channel[[:blank:]]${CHANNEL_NUM}[[:blank:]]?:")
         if [[ -z "${CHANNEL_INFO}" ]]; then
-            [[ $CHANNEL_NUM -eq $WIFI_IFACE_CHANNEL ]] && return 1
+            if (! $USING_DEFAULT_CHANNEL) || [[ $CHANNEL_NUM -eq $WIFI_IFACE_CHANNEL ]]; then
+                return 1
+            fi
 
             # Attempt to use the channel of the interface
             echo "Unable to transmit using channel $CHANNEL_NUM. Attempting $WIFI_IFACE_CHANNEL." >&2
@@ -1419,11 +1423,14 @@ if [[ $FREQ_BAND != 2.4 && $FREQ_BAND != 5 ]]; then
 fi
 
 if [[ $CHANNEL == default ]]; then
+    USING_DEFAULT_CHANNEL=true
     if [[ $FREQ_BAND == 2.4 ]]; then
         CHANNEL=1
     else
         CHANNEL=36
     fi
+else
+    USING_DEFAULT_CHANNEL=false
 fi
 
 if [[ $FREQ_BAND != 5 && $CHANNEL -gt 14 ]]; then


### PR DESCRIPTION
This patch attempts to fallback to an existing $WIFI_IFACE_CHANNEL if
current $CHANNEL does not work. In cases, hardware reports as multiple
channels available to transmit, hence the script uses channel 1 as
default. But it fails when trying to transmit on channel 1.

This patch modifies can_transmit_to_channel function to check if
$CHANNEL is equal to $WIFI_IFACE_CHANNEL. If not, it sets $CHANNEL to be
the same as $WIFI_IFACE_CHANNEL and checks can_transmit_to_channel. If
passed, ap is created on the same channel as $WIFI_IFACE_CHANNEL. Else,
it safely fails.
