### PR TITLE
Wait for create_ap to exit after AP-ENABLED in UI

### DIFF
--- a/src/ui/ui.c
+++ b/src/ui/ui.c
@@ -773,6 +773,7 @@ static void *run_create_hp_shell(void *cmd) {
 
         if (strstr(buf, AP_ENABLED) != NULL) {
             init_running_info();
+            pclose(fp);
             return 0;
         }
     }


### PR DESCRIPTION
To create a hotspot, the UI launches `create_ap` with `popen` and waits for it to print "AP-ENABLED" to confirm the hotspot has been created. When this happens, it immediately returns, without calling `pclose`.

This not only leaks the `FILE *` opened by `popen`, but it can also inadvertently cause `create_ap` to get terminated:
* The user launches `wihotspot-gui` as root
* `wihotspot-gui` launches `pkexec --user root create_ap ...`
* [`pkexec` sets a `SIGTERM` parent-death signal via `prctl`](https://github.com/polkit-org/polkit/blob/7d44d62a02f090a5a71c4ca10d58c7c2b54881eb/src/programs/pkexec.c#L757)
* `pkexec` launches `create_ap` and it starts running
* `create_ap` creates the hotspot and prints "AP-ENABLED"
* `wihotspot-gui` updates the UI, and returns without waiting for `create_ap` to exit
* Immediately after, the `init_running_info` thread exits
* A `SIGTERM` parent-death signal is sent to `create_ap`
* `create_ap` terminates and the hotspot stops running

(This only reproduces if `wihotspot-gui` runs as root, likely due to setuid restrictions for `prctl` applying otherwise)

Wait for `create_ap` to exit using `pclose` to fix the problem.