### PR TITLE
Fix build with GCC 9

### DIFF
--- a/src/ui/ui.c
+++ b/src/ui/ui.c
@@ -131,7 +131,7 @@ static ConfigValues configValues;
 
 
 
-static void *stopHp(void *) {
+static void *stopHp(void *unused) {
     if(running_info[0]!=NULL){
         gtk_label_set_label(label_status,"Stopping ...");
         start_pb_pulse();
@@ -710,7 +710,7 @@ void clear_running_info(){
         running_info[0]=NULL;
 }
 
-void* init_running_info(void *){
+void* init_running_info(void *unused){
 
     clear_running_info();
     lock_all_views(TRUE);


### PR DESCRIPTION
This PR fixes the problem created by #481 with old GCC 9 (for example `gcc
(Ubuntu 9.4.0-1ubuntu1~20.04.2) 9.4.0`):
```shell
gcc -c -o ../build/ui.o ui/ui.c `pkg-config --cflags gtk+-3.0`
ui/ui.c: In function ‘stopHp’:
ui/ui.c:134:21: error: parameter name omitted
  134 | static void *stopHp(void *) {
      |                     ^~~~~~
ui/ui.c: In function ‘init_running_info’:
ui/ui.c:713:25: error: parameter name omitted
  713 | void* init_running_info(void *){
      |                         ^~~~~~
```
