### PR TITLE
OTP Feature Implementation

### DIFF
--- a/src/ui/glade/wifih.ui
+++ b/src/ui/glade/wifih.ui
@@ -100,6 +100,24 @@
                 <property name="position">3</property>
               </packing>
             </child>
+            <child>
+              <object class="GtkCheckButton" id="check_otp">
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="label" translatable="yes">One-time password</property>
+                <property name="tooltip_text" translatable="yes">
+                  Generate a random password valid only for this hotspot session
+                </property>
+                <property name="receives_default">False</property>
+                <signal name="toggled" handler="on_otp_toggled" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="padding">2</property>
+                <property name="position">4</property>
+              </packing>
+            </child>
           </object>
           <packing>
             <property name="expand">False</property>

--- a/src/ui/ui.h
+++ b/src/ui/ui.h
@@ -40,6 +40,8 @@ typedef struct {
     GtkEntry *pass;
 } WIData;
 
+extern GtkCheckButton *cb_otp;
+
 int initUi(int argc, char *argv[]);
 
 void init_ui_from_config();
@@ -83,6 +85,8 @@ static void on_cb_channel_toggle(GtkWidget *widget, gpointer data);
 static void on_cb_mac_filter_toggle(GtkWidget *widget, gpointer data);
 
 static void on_cb_gateway_toggle(GtkWidget *widget, gpointer data);
+
+static void on_otp_toggled(GtkToggleButton *btn, gpointer data);
 
 static void clear_connecetd_devices_list();
 


### PR DESCRIPTION
One-Time Password (OTP) mode

Tick the new checkbox under the Password field → a cryptographically-random 12-character passphrase is generated every time Create Hotspot is pressed.

The OTP is displayed, copied to the QR dialog, and used for that session only.

Password-restore logic

The user’s original passphrase is cached in memory.

Unticking One-time password restores that original value automatically, so clicking Create Hotspot afterwards never writes an OTP to create_ap.conf.

UI/UX refinements

Password entry is read-only while OTP is active.

Validation and QR-generation paths work transparently with either fixed or one-time passwords.