### PR TITLE
Change shebang for portability.

### DIFF
--- a/src/scripts/create_ap
+++ b/src/scripts/create_ap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # general dependencies:
 #    bash (to run this script)


### PR DESCRIPTION
`#!/bin/bash` breaks on systems that put bash somewhere else (like `/usr/bin/bash` or a NixOS situation where it's in `/nix/store` somewhere). This is more portable.