### PR TITLE
Fix BSS overflow in config parser (SIGSEGV with default config)

### DIFF
--- a/src/ui/read_config.cpp
+++ b/src/ui/read_config.cpp
@@ -39,7 +39,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "read_config.h"
 
-#define CONFIG_KEY_COUNT 30
+#define CONFIG_KEY_COUNT 64
 #define STRING_MAX_LENGTH 100
 #define BUFSIZE 150
 
@@ -56,7 +56,7 @@ int read_config_file() {
         std::string line;
 
         int i=0;
-        while (getline(cFile, line)) {
+        while (getline(cFile, line) && i < CONFIG_KEY_COUNT) {
             auto delimiterPos = line.find('=');
             if (!(line.find("SSID") < delimiterPos) && !(line.find("PASSPHRASE") < delimiterPos)) {
                 line.erase(std::remove_if(line.begin(), line.end(), isspace),
@@ -68,7 +68,10 @@ int read_config_file() {
             auto name = line.substr(0, delimiterPos);
             auto value = line.substr(delimiterPos + 1);
 
-            strcpy(configs[i],value.c_str());
+            if (value.size() >= STRING_MAX_LENGTH)
+                value.resize(STRING_MAX_LENGTH - 1);
+            memcpy(configs[i], value.c_str(), value.size());
+            configs[i][value.size()] = '\0';
             setConfigValues(name.c_str(),configs[i]);
             //std::cout << name << " " << value << '\n';
             ++i;

--- a/src/ui/ui.c
+++ b/src/ui/ui.c
@@ -514,7 +514,7 @@ void init_ui_from_config(){
         if(values->pass!=NULL)
             gtk_entry_set_text(entry_pass,values->pass);
 
-        if(strcmp(values->pass,"")==0|| values->pass==NULL)
+        if(values->pass==NULL || strcmp(values->pass,"")==0)
             // This line will trigger on_cb_open_toggle callback and disable the entry_pass
             gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(cb_open),TRUE);
 


### PR DESCRIPTION
## Summary
`read_config_file()` in `src/ui/read_config.cpp` declares
`configs[CONFIG_KEY_COUNT=30][100]` but the default `/etc/create_ap.conf`
shipped by this project contains **33 keys**. The `strcpy` loop writes
past the end of the array into adjacent BSS, corrupting the
`configValues` struct and other globals. The GUI then crashes during
startup as soon as the user-set `PASSPHRASE` reaches ~10 characters,
because the overflowed byte(s) clobber a pointer that `ui.c`
dereferences shortly afterwards.

Strace confirms the crash happens immediately after the read of
`/etc/create_ap.conf`, before any GTK window code runs:

```
read(13, "CHANNEL=default\nGATEWAY=192.168."..., 8191) = 527
read(13, "", 8191)                      = 0
close(13)                               = 0
--- SIGSEGV {si_signo=SIGSEGV, si_code=SI_KERNEL, si_addr=NULL} ---
+++ killed by SIGSEGV +++
```

## Fixes
- Bump `CONFIG_KEY_COUNT` from 30 → 64 (still cheap, ~3 KiB BSS).
- Add an `i < CONFIG_KEY_COUNT` guard so any further growth of the
  config file can never overflow again.
- Replace the unbounded `strcpy()` with a length-capped `memcpy()` so an
  oversized value (≥ `STRING_MAX_LENGTH`) is truncated rather than
  smashing the row.
- Reorder a latent NULL-then-`strcmp` in `init_ui_from_config`
  (`if(strcmp(values->pass,"")==0|| values->pass==NULL)` → NULL test
  first) so a missing `PASSPHRASE=` line cannot also crash here.

## Reproducer (before patch)
```
# any passphrase >= 10 chars in /etc/create_ap.conf
PASSPHRASE=2444666668888888
$ wihotspot-gui
Segmentation fault
```
After the patch the GUI loads as expected with the same config.

## Test plan
- [x] Built and installed locally (Void Linux, `linux-wifi-hotspot 4.7.2`); GUI now starts with 16-character passphrases that previously segfaulted.
- [x] GUI still starts cleanly with the shipped default config (`SSID=MyAccessPoint`, `PASSPHRASE=12345678`).
- [ ] No regression in other config-loading paths reviewed by maintainers.