### PR TITLE
Improve hotspot reliability, GUI management, and multi-interface support

### DIFF
--- a/src/scripts/create_ap
+++ b/src/scripts/create_ap
@@ -75,6 +75,7 @@ usage() {
     echo "  --stop <id>             Send stop command to an already running create_ap. For an <id>"
     echo "                          you can put the PID of create_ap or the WiFi interface. You can"
     echo "                          get them with --list-running"
+    echo "  --show-info <id>        Show SSID, security and other details for a running hotspot"
     echo "  --list-running          Show the create_ap processes that are already running"
     echo "  --list-clients <id>     List the clients connected to create_ap instance associated with <id>."
     echo "                          For an <id> you can put the PID of create_ap or the WiFi interface."
@@ -321,6 +322,45 @@ can_be_ap() {
     return 1
 }
 
+can_use_multiple_channels_with_ap() {
+    [[ $USE_IWCONFIG -eq 1 ]] && return 1
+    get_adapter_info "$1" | grep -E '\{[^}]*AP[^}]*\}[^#]*#channels <= [2-9]' > /dev/null 2>&1 && return 0
+    return 1
+}
+
+sync_channel_with_wifi_connection() {
+    local iface=$1
+    local connected_freq connected_channel
+
+    is_wifi_connected ${iface} || return 0
+
+    connected_freq=$(iw dev ${iface} link | grep -i freq | awk '{print $2}')
+    connected_channel=$(ieee80211_frequency_to_channel ${connected_freq})
+    WIFI_IFACE_CHANNEL=$connected_channel
+
+    if [[ $FREQ_BAND_SET -eq 0 ]]; then
+        if is_5ghz_frequency $connected_freq; then
+            FREQ_BAND=5
+        else
+            FREQ_BAND=2.4
+        fi
+    fi
+
+    if [[ $connected_channel -eq $CHANNEL ]]; then
+        echo "${iface} is already associated with channel ${connected_channel} (${connected_freq} MHz)"
+        return 0
+    fi
+
+    if can_use_multiple_channels_with_ap ${iface}; then
+        echo "${iface} is associated with channel ${connected_channel}; using channel ${CHANNEL} (multi-channel supported)"
+        return 0
+    fi
+
+    echo "${iface} is already associated with channel ${connected_channel} (${connected_freq} MHz)"
+    echo "Falling back to channel ${connected_channel}"
+    CHANNEL=$connected_channel
+}
+
 can_transmit_to_channel() {
     local IFACE CHANNEL_NUM CHANNEL_INFO
     IFACE=$1
@@ -442,6 +482,152 @@ get_new_macaddr() {
     done
     mutex_unlock
     echo $NEWMAC
+}
+
+get_running_pid_for_wifi_iface() {
+    local wifi_iface=$1
+    local pid iface rest
+
+    while read -r pid iface rest; do
+        [[ -z "$pid" ]] && continue
+        [[ "$iface" == "$wifi_iface" ]] && echo "$pid" && return 0
+    done < <(list_running)
+
+    return 1
+}
+
+remove_ap_interfaces_on_phy() {
+    local wifi_iface=$1
+    local target_phy iface iface_phy iface_type pid
+
+    [[ $USE_IWCONFIG -eq 1 ]] && return 0
+    target_phy=$(get_phy_device "$wifi_iface") || return 0
+
+    while read -r iface; do
+        [[ -z "$iface" ]] && continue
+        is_wifi_interface "$iface" || continue
+        iface_type=$(iw dev "$iface" info 2>/dev/null | awk '/type/ {print $2; exit}')
+        [[ "$iface_type" == "AP" ]] || continue
+        iface_phy=$(get_phy_device "$iface" 2>/dev/null) || continue
+        [[ "$iface_phy" == "$target_phy" ]] || continue
+
+        pid=$(get_pid_from_wifi_iface "$iface")
+        [[ -z "$pid" ]] && pid=$(get_running_pid_for_wifi_iface "$wifi_iface" || true)
+        if [[ -n "$pid" ]] && is_running_pid "$pid"; then
+            continue
+        fi
+
+        echo "Removing AP interface $iface..."
+        ip link set dev "$iface" down 2>/dev/null
+        iw dev "$iface" del 2>/dev/null
+        dealloc_iface "$iface" 2>/dev/null
+    done < <(iw dev | awk '/Interface/ {print $2}')
+}
+
+cleanup_stale_ap_interfaces() {
+    local wifi_iface=$1
+    local target_phy iface iface_phy iface_type pid
+
+    [[ $USE_IWCONFIG -eq 1 ]] && return 0
+    target_phy=$(get_phy_device "$wifi_iface") || return 0
+
+    while read -r iface; do
+        [[ -z "$iface" ]] && continue
+        is_wifi_interface "$iface" || continue
+        iface_type=$(iw dev "$iface" info 2>/dev/null | awk '/type/ {print $2; exit}')
+        [[ "$iface_type" == "AP" ]] || continue
+        iface_phy=$(get_phy_device "$iface" 2>/dev/null) || continue
+        [[ "$iface_phy" == "$target_phy" ]] || continue
+
+        pid=$(get_pid_from_wifi_iface "$iface")
+        if [[ -n "$pid" ]] && is_running_pid "$pid"; then
+            die "Hotspot already running on $iface (PID $pid). Stop it first: create_ap --stop $wifi_iface"
+        fi
+
+        echo "Removing stale AP interface $iface..."
+        ip link set dev "$iface" down 2>/dev/null
+        iw dev "$iface" del 2>/dev/null
+        dealloc_iface "$iface" 2>/dev/null
+    done < <(iw dev | awk '/Interface/ {print $2}')
+}
+
+find_create_ap_confdirs_for_iface() {
+    local wifi_iface=$1
+    local x
+
+    for x in /tmp/create_ap.${wifi_iface}.conf.*; do
+        [[ -d "$x" ]] && echo "$x"
+    done
+}
+
+cleanup_orphaned_create_ap_confdir() {
+    local confdir=$1
+    local pid y
+
+    [[ -d "$confdir" ]] || return 0
+    if [[ -f "$confdir/pid" ]]; then
+        pid=$(cat "$confdir/pid" 2>/dev/null)
+        if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+            return 0
+        fi
+    fi
+
+    echo "Cleaning orphaned hotspot data from $confdir..."
+    for y in "$confdir"/*.pid; do
+        [[ -f "$y" ]] && kill -9 $(cat "$y") 2>/dev/null
+    done
+    pkill -f "dnsmasq -C ${confdir}/dnsmasq.conf" 2>/dev/null || true
+    rm -rf "$confdir"
+}
+
+cleanup_orphaned_create_ap_for_iface() {
+    local wifi_iface=$1
+    local x
+
+    for x in $(find_create_ap_confdirs_for_iface "$wifi_iface"); do
+        cleanup_orphaned_create_ap_confdir "$x"
+    done
+}
+
+gateway_subnet_conflicts() {
+    local gw=$1
+    local gw_prefix="${gw%.*}"
+    local cidr ip
+
+    if ip route show default 2>/dev/null | grep -Eq "[[:space:]]via ${gw}[[:space:]]"; then
+        return 0
+    fi
+
+    while read -r cidr; do
+        ip="${cidr%%/*}"
+        [[ "${ip%.*}" == "$gw_prefix" ]] && return 0
+    done < <(ip -4 -o addr show scope global | awk '{print $4}')
+
+    return 1
+}
+
+pick_alternate_gateway() {
+    local candidate
+
+    for candidate in 192.168.43.1 10.42.0.1 192.168.4.1 172.16.42.1; do
+        if ! gateway_subnet_conflicts "$candidate"; then
+            echo "$candidate"
+            return 0
+        fi
+    done
+
+    echo "10.42.0.1"
+}
+
+adjust_gateway_for_conflicts() {
+    local new_gw
+
+    if gateway_subnet_conflicts "$GATEWAY"; then
+        new_gw=$(pick_alternate_gateway)
+        echo "WARN: Gateway ${GATEWAY} conflicts with an existing network connection." >&2
+        echo "WARN: Using alternate gateway ${new_gw} instead." >&2
+        GATEWAY=$new_gw
+    fi
 }
 
 # start haveged when needed
@@ -683,6 +869,7 @@ CONFIG_OPTS=(CHANNEL GATEWAY WPA_VERSION ETC_HOSTS DHCP_DNS NO_DNS NO_DNSMASQ HI
 FIX_UNMANAGED=0
 LIST_RUNNING=0
 STOP_ID=
+SHOW_INFO_ID=
 LIST_CLIENTS_ID=
 
 STORE_CONFIG=
@@ -701,6 +888,11 @@ HAVEGED_WATCHDOG_PID=
 
 _cleanup() {
     local PID x
+    local ap_iface saved_wifi_iface
+
+    [[ -f "$CONFDIR/wifi_iface" ]] && ap_iface=$(cat "$CONFDIR/wifi_iface")
+    saved_wifi_iface=$PHYS_WIFI_IFACE
+    [[ -z "$saved_wifi_iface" ]] && saved_wifi_iface=$WIFI_IFACE
 
     trap "" SIGINT SIGUSR1 SIGUSR2 EXIT
     mutex_lock
@@ -813,13 +1005,15 @@ _cleanup() {
     fi
 
     if [[ $NO_VIRT -eq 0 ]]; then
-        if [[ -n "$VWIFI_IFACE" ]]; then
-            ip link set down dev ${VWIFI_IFACE}
-            ip addr flush ${VWIFI_IFACE}
+        [[ -z "$VWIFI_IFACE" && -n "$ap_iface" ]] && VWIFI_IFACE=$ap_iface
+        if [[ -n "$VWIFI_IFACE" ]] && is_interface "$VWIFI_IFACE"; then
+            ip link set down dev ${VWIFI_IFACE} 2>/dev/null
+            ip addr flush ${VWIFI_IFACE} 2>/dev/null
             networkmanager_rm_unmanaged_if_needed ${VWIFI_IFACE} ${OLD_MACADDR}
-            iw dev ${VWIFI_IFACE} del
+            iw dev ${VWIFI_IFACE} del 2>/dev/null
             dealloc_iface $VWIFI_IFACE
         fi
+        [[ -n "$saved_wifi_iface" ]] && remove_ap_interfaces_on_phy "$saved_wifi_iface"
     else
         ip link set down dev ${WIFI_IFACE}
         ip addr flush ${WIFI_IFACE}
@@ -838,10 +1032,9 @@ _cleanup() {
 }
 
 cleanup() {
-    echo
-    echo -n "Doing cleanup.. "
+    { echo; echo -n "Doing cleanup.. "; } 2>/dev/null || true
     _cleanup > /dev/null 2>&1
-    echo "done"
+    { echo "done"; } 2>/dev/null || true
 }
 
 die() {
@@ -975,7 +1168,7 @@ has_running_instance() {
             fi
         fi
     done
-    mutex_lock
+    mutex_unlock
 
     return 1
 }
@@ -985,21 +1178,179 @@ is_running_pid() {
 }
 
 send_stop() {
-    local x
+    local id=$1
+    local x pid wifi_iface confdir
+    local stopped=0
 
-    mutex_lock
-    # send stop signal to specific pid
-    if is_running_pid $1; then
-        kill -USR1 $1
-        mutex_unlock
-        return
+    if [[ "$id" =~ ^[1-9][0-9]*$ ]] && is_running_pid "$id"; then
+        pid=$id
+        wifi_iface=$(get_wifi_iface_from_pid "$pid" 2>/dev/null)
+    else
+        wifi_iface=$id
+        pid=$(get_running_pid_for_wifi_iface "$wifi_iface" || true)
+        [[ -z "$pid" ]] && pid=$(get_pid_from_wifi_iface "$wifi_iface" 2>/dev/null)
     fi
 
-    # send stop signal to specific interface
-    for x in $(list_running | grep -E " \(?${1}( |\)?\$)" | cut -f1 -d' '); do
-        kill -USR1 $x
+    if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+        kill -USR1 "$pid" 2>/dev/null
+        for x in $(seq 1 15); do
+            kill -0 "$pid" 2>/dev/null || break
+            sleep 0.2
+        done
+        if kill -0 "$pid" 2>/dev/null; then
+            echo "Force stopping create_ap (PID $pid)..."
+            kill -9 "$pid" 2>/dev/null
+            sleep 0.3
+        fi
+        stopped=1
+    fi
+
+    if [[ -n "$pid" ]]; then
+        confdir=$(get_confdir_from_pid "$pid" 2>/dev/null)
+        if [[ -z "$confdir" ]]; then
+            for x in $(find_create_ap_confdirs_for_iface "$wifi_iface"); do
+                if [[ -f "$x/pid" && $(cat "$x/pid" 2>/dev/null) == "$pid" ]]; then
+                    confdir=$x
+                    break
+                fi
+            done
+        fi
+        if [[ -n "$confdir" && -d "$confdir" ]]; then
+            for y in "$confdir"/*.pid; do
+                [[ -f "$y" ]] && kill -9 $(cat "$y") 2>/dev/null
+            done
+            rm -rf "$confdir"
+            stopped=1
+        fi
+    fi
+
+    if [[ -n "$wifi_iface" ]]; then
+        cleanup_orphaned_create_ap_for_iface "$wifi_iface"
+    elif [[ -n "$id" ]]; then
+        cleanup_orphaned_create_ap_for_iface "$id"
+        [[ -z "$wifi_iface" ]] && wifi_iface=$id
+    fi
+
+    [[ -n "$wifi_iface" ]] && remove_ap_interfaces_on_phy "$wifi_iface"
+    [[ -z "$wifi_iface" && -n "$id" ]] && remove_ap_interfaces_on_phy "$id"
+
+    if [[ $stopped -eq 1 ]]; then
+        echo "Hotspot stopped on ${wifi_iface:-$id}."
+    elif [[ -n "$wifi_iface" || -n "$id" ]]; then
+        echo "Forced cleanup completed for ${wifi_iface:-$id}."
+    else
+        echo "No running hotspot found for $id." >&2
+    fi
+}
+
+find_running_confdir_for_id() {
+    local id=$1
+    local x pid iface
+
+    if [[ "$id" =~ ^[1-9][0-9]*$ ]]; then
+        for x in /tmp/create_ap.*; do
+            [[ -d "$x" && -f "$x/pid" ]] || continue
+            pid=$(cat "$x/pid" 2>/dev/null)
+            [[ "$pid" == "$id" && -d "/proc/$pid" ]] || continue
+            echo "$x"
+            return 0
+        done
+        return 1
+    fi
+
+    iface=$id
+    for x in /tmp/create_ap.${iface}.conf.*; do
+        [[ -d "$x" && -f "$x/pid" ]] || continue
+        pid=$(cat "$x/pid" 2>/dev/null)
+        [[ -n "$pid" && -d "/proc/$pid" ]] || continue
+        echo "$x"
+        return 0
     done
-    mutex_unlock
+
+    return 1
+}
+
+make_confdir_info_readable() {
+    [[ -f "$CONFDIR/hostapd.conf" ]] && chmod 444 "$CONFDIR/hostapd.conf"
+    [[ -f "$CONFDIR/dnsmasq.conf" ]] && chmod 444 "$CONFDIR/dnsmasq.conf"
+    [[ -f "$CONFDIR/nat_internet_iface" ]] && chmod 444 "$CONFDIR/nat_internet_iface"
+}
+
+show_hotspot_info() {
+    local id=$1
+    local confdir pid phy_iface ap_iface internet_iface="none"
+    local ssid="" channel="" hw_mode="" hidden="0"
+    local wpa="" key_mgmt="" passphrase="" psk="" gateway="" encryption="" band=""
+
+    confdir=$(find_running_confdir_for_id "$id") || die "No running hotspot found for $id"
+
+    [[ -f "$confdir/pid" ]] && pid=$(cat "$confdir/pid")
+    [[ -f "$confdir/wifi_iface" ]] && ap_iface=$(cat "$confdir/wifi_iface")
+    [[ -f "$confdir/nat_internet_iface" ]] && internet_iface=$(cat "$confdir/nat_internet_iface")
+
+    phy_iface=${confdir#/tmp/create_ap.}
+    phy_iface=${phy_iface%%.conf.*}
+
+    if [[ -f "$confdir/hostapd.conf" ]]; then
+        while IFS= read -r line; do
+            case "$line" in
+                ssid=*) ssid="${line#ssid=}" ;;
+                channel=*) channel="${line#channel=}" ;;
+                hw_mode=*) hw_mode="${line#hw_mode=}" ;;
+                ignore_broadcast_ssid=*) hidden="${line#ignore_broadcast_ssid=}" ;;
+                wpa=*) wpa="${line#wpa=}" ;;
+                wpa_key_mgmt=*) key_mgmt="${line#wpa_key_mgmt=}" ;;
+                wpa_passphrase=*) passphrase="${line#wpa_passphrase=}" ;;
+                wpa_psk=*) psk="${line#wpa_psk=}" ;;
+            esac
+        done < "$confdir/hostapd.conf"
+    fi
+
+    if [[ -f "$confdir/dnsmasq.conf" ]]; then
+        gateway=$(grep -m1 '^listen-address=' "$confdir/dnsmasq.conf" | cut -d= -f2-)
+    fi
+
+    if [[ -z "$passphrase" && -n "$psk" ]]; then
+        passphrase=$psk
+    fi
+
+    if [[ -z "$passphrase" && -z "$psk" ]]; then
+        encryption="Open"
+    elif [[ "$key_mgmt" == *SAE* ]]; then
+        encryption="WPA2/WPA3"
+    elif [[ "$wpa" == "3" ]]; then
+        encryption="WPA3"
+    elif [[ "$wpa" == "2" ]]; then
+        encryption="WPA2-PSK"
+    elif [[ "$wpa" == "1" ]]; then
+        encryption="WPA-PSK"
+    elif [[ -n "$psk" ]]; then
+        encryption="WPA-PSK (hex)"
+    else
+        encryption="WPA-PSK"
+    fi
+
+    if [[ "$hw_mode" == "a" ]]; then
+        band="5 GHz"
+    elif [[ "$hw_mode" == "g" ]]; then
+        band="2.4 GHz"
+    fi
+
+    echo "PID=${pid:-}"
+    echo "PHY_IFACE=${phy_iface:-}"
+    echo "AP_IFACE=${ap_iface:-}"
+    echo "INTERNET_IFACE=${internet_iface:-none}"
+    echo "SSID=${ssid:-}"
+    echo "PASSPHRASE=${passphrase:-}"
+    echo "ENCRYPTION=${encryption:-}"
+    echo "GATEWAY=${gateway:-}"
+    echo "CHANNEL=${channel:-}"
+    echo "BAND=${band:-}"
+    if [[ "$hidden" == "1" ]]; then
+        echo "HIDDEN=Yes"
+    else
+        echo "HIDDEN=No"
+    fi
 }
 
 # Storing configs
@@ -1103,7 +1454,7 @@ for ((i=0; i<$#; i++)); do
     fi
 done
 
-GETOPT_ARGS=$(getopt -o hc:w:g:de:nm: -l "help","hidden","hostapd-debug:","hostapd-timestamps","redirect-to-localhost","mac-filter","mac-filter-accept:","isolate-clients","ieee80211n","ieee80211ac","ieee80211ax","ht_capab:","vht_capab:","driver:","no-virt","fix-unmanaged","country:","freq-band:","mac:","dhcp-dns:","daemon","pidfile:","logfile:","dns-logfile:","stop:","list","list-running","list-clients:","version","psk","no-haveged","no-dns","no-dnsmasq","mkconfig:","config:","dhcp-hosts:" -n "$PROGNAME" -- "$@")
+GETOPT_ARGS=$(getopt -o hc:w:g:de:nm: -l "help","hidden","hostapd-debug:","hostapd-timestamps","redirect-to-localhost","mac-filter","mac-filter-accept:","isolate-clients","ieee80211n","ieee80211ac","ieee80211ax","ht_capab:","vht_capab:","driver:","no-virt","fix-unmanaged","country:","freq-band:","mac:","dhcp-dns:","daemon","pidfile:","logfile:","dns-logfile:","stop:","show-info:","list","list-running","list-clients:","version","psk","no-haveged","no-dns","no-dnsmasq","mkconfig:","config:","dhcp-hosts:" -n "$PROGNAME" -- "$@")
 [[ $? -ne 0 ]] && exit 1
 eval set -- "$GETOPT_ARGS"
 
@@ -1253,6 +1604,11 @@ while :; do
             STOP_ID="$1"
             shift
             ;;
+        --show-info)
+            shift
+            SHOW_INFO_ID="$1"
+            shift
+            ;;
         --list)
             shift
             LIST_RUNNING=1
@@ -1334,7 +1690,7 @@ if [[ -n "$LOAD_CONFIG" && $# -eq 0 ]]; then
 fi
 
 # Check if required number of positional args are present
-if [[ $# -lt 1 && $FIX_UNMANAGED -eq 0  && -z "$STOP_ID" &&
+if [[ $# -lt 1 && $FIX_UNMANAGED -eq 0  && -z "$STOP_ID" && -z "$SHOW_INFO_ID" &&
       $LIST_RUNNING -eq 0 && -z "$LIST_CLIENTS_ID" ]]; then
     usage >&2
     exit 1
@@ -1382,6 +1738,11 @@ if [[ -n "$STOP_ID" ]]; then
     exit 0
 fi
 
+if [[ -n "$SHOW_INFO_ID" ]]; then
+    show_hotspot_info "$SHOW_INFO_ID"
+    exit 0
+fi
+
 if [[ $FIX_UNMANAGED -eq 1 ]]; then
     echo "Trying to fix unmanaged status in NetworkManager..."
     networkmanager_fix_unmanaged
@@ -1412,8 +1773,10 @@ if [[ $CHANNEL == default ]]; then
     USING_DEFAULT_CHANNEL=1
     if [[ $FREQ_BAND == 2.4 ]]; then
         CHANNEL=1
-    else
+    elif [[ $FREQ_BAND == 5 ]]; then
         CHANNEL=36
+    else
+        CHANNEL=1
     fi
 else
     USING_DEFAULT_CHANNEL=0
@@ -1426,6 +1789,7 @@ if [[ $FREQ_BAND != 5 && $CHANNEL -gt 14 ]]; then
 fi
 
 WIFI_IFACE=$1
+PHYS_WIFI_IFACE=$WIFI_IFACE
 
 if ! is_wifi_interface ${WIFI_IFACE}; then
     echo "ERROR: '${WIFI_IFACE}' is not a WiFi interface" >&2
@@ -1593,6 +1957,15 @@ if [[ $NO_VIRT -eq 1 && "$WIFI_IFACE" == "$INTERNET_IFACE" ]]; then
     exit 1
 fi
 
+cleanup_orphaned_create_ap_for_iface ${WIFI_IFACE}
+
+existing_pid=$(get_running_pid_for_wifi_iface ${WIFI_IFACE} || true)
+if [[ -n "$existing_pid" ]]; then
+    echo "ERROR: Hotspot already running on ${WIFI_IFACE} (PID ${existing_pid})." >&2
+    echo "Stop it first: create_ap --stop ${WIFI_IFACE}" >&2
+    exit 1
+fi
+
 mutex_lock
 trap "cleanup" EXIT
 CONFDIR=$(mktemp -d /tmp/create_ap.${WIFI_IFACE}.conf.XXXXXXXX)
@@ -1610,6 +1983,7 @@ mkdir -p $COMMON_CONFDIR
 
 if [[ "$SHARE_METHOD" == "nat" ]]; then
     echo $INTERNET_IFACE > $CONFDIR/nat_internet_iface
+    chmod 444 $CONFDIR/nat_internet_iface
     cp_n /proc/sys/net/ipv4/conf/$INTERNET_IFACE/forwarding \
        $COMMON_CONFDIR/${INTERNET_IFACE}_forwarding
 fi
@@ -1632,6 +2006,7 @@ if [[ $USE_IWCONFIG -eq 0 ]]; then
 fi
 
 if [[ $NO_VIRT -eq 0 ]]; then
+    cleanup_stale_ap_interfaces ${WIFI_IFACE}
     VWIFI_IFACE=$(alloc_new_iface ap)
 
     # in NetworkManager 0.9.9 and above we can set the interface as unmanaged without
@@ -1645,34 +2020,9 @@ if [[ $NO_VIRT -eq 0 ]]; then
     fi
 
 
-    if is_wifi_connected ${WIFI_IFACE} && [[ $FREQ_BAND_SET -eq 0 ]]; then
-        WIFI_IFACE_FREQ=$(iw dev ${WIFI_IFACE} link | grep -i freq | awk '{print $2}')
-        WIFI_IFACE_CHANNEL=$(ieee80211_frequency_to_channel ${WIFI_IFACE_FREQ})
-        echo -n "${WIFI_IFACE} is already associated with channel ${WIFI_IFACE_CHANNEL} (${WIFI_IFACE_FREQ} MHz)"
-        if is_5ghz_frequency $WIFI_IFACE_FREQ; then
-            FREQ_BAND=5
-        else
-            FREQ_BAND=2.4
-        fi
-        if [[ $WIFI_IFACE_CHANNEL -ne $CHANNEL ]]; then
-            if ( get_adapter_info ${IFACE} | grep "#channels <= 2" -q )
-            then
-                echo -e "\nmultiple channels supported"
-            else
-                echo -e  "\nmultiple channels not supported",
-                echo -e  "\nfallback to channel ${WIFI_IFACE_CHANNEL}"
-                CHANNEL=$WIFI_IFACE_CHANNEL
-            fi
-        else
-            echo "channel------------------ ${CHANNEL}"
-        fi
-    elif is_wifi_connected ${WIFI_IFACE} && [[ $FREQ_BAND_SET -eq 1 ]]; then
-        echo "Custom frequency band set with ${FREQ_BAND}Ghz with channel ${CHANNEL}"
-    fi
-
-
-    VIRTDIEMSG="Maybe your WiFi adapter does not fully support virtual interfaces.
-       Try again with --no-virt."
+    VIRTDIEMSG="Maybe your WiFi adapter does not fully support virtual interfaces,
+       or another AP interface is already active on this adapter.
+       Stop any running hotspot first, or try again with --no-virt."
     echo -n "Creating a virtual WiFi interface... "
 
     if iw dev ${WIFI_IFACE} interface add ${VWIFI_IFACE} type __ap; then
@@ -1692,6 +2042,8 @@ else
     OLD_MACADDR=$(get_macaddr ${WIFI_IFACE})
 fi
 
+sync_channel_with_wifi_connection ${PHYS_WIFI_IFACE}
+
 mutex_lock
 echo $WIFI_IFACE > $CONFDIR/wifi_iface
 chmod 444 $CONFDIR/wifi_iface
@@ -1705,7 +2057,7 @@ fi
 if can_transmit_to_channel "${WIFI_IFACE}" "${CHANNEL}"; then
     echo "Transmitting to channel ${CHANNEL}..."
 else
-    if [[ $USING_DEFAULT_CHANNEL -eq 1 && $WIFI_IFACE_CHANNEL -ne $CHANNEL ]]; then
+    if [[ $USING_DEFAULT_CHANNEL -eq 1 && -n "$WIFI_IFACE_CHANNEL" && $WIFI_IFACE_CHANNEL -ne $CHANNEL ]]; then
         echo -e "Your adapter can not transmit to channel ${CHANNEL}" >&2
         CHANNEL=$WIFI_IFACE_CHANNEL
         echo -e "Falling back to channel ${CHANNEL}"
@@ -1823,6 +2175,10 @@ EOF
 fi
 
 
+if [[ "$SHARE_METHOD" != "bridge" ]]; then
+    adjust_gateway_for_conflicts
+fi
+
 if [[ "$SHARE_METHOD" == "bridge" ]]; then
     echo "bridge=${BRIDGE_IFACE}" >> $CONFDIR/hostapd.conf
 elif [[ $NO_DNSMASQ -eq 0 ]]; then
@@ -1867,6 +2223,8 @@ address=/#/$GATEWAY
 EOF
     fi
 fi
+
+make_confdir_info_readable
 
 # initialize WiFi interface
 if [[ $NO_VIRT -eq 0 && -n "$NEW_MACADDR" ]]; then
@@ -2015,23 +2373,35 @@ STDBUF_PATH=`which stdbuf`
 if [ $? -eq 0 ]; then
     STDBUF_PATH=$STDBUF_PATH" -oL"
 fi
-$STDBUF_PATH $HOSTAPD $HOSTAPD_DEBUG_ARGS $CONFDIR/hostapd.conf &
+# Keep hostapd off create_ap stdout so GUI/caller pipes are not closed early (SIGPIPE).
+$STDBUF_PATH $HOSTAPD $HOSTAPD_DEBUG_ARGS $CONFDIR/hostapd.conf >> "$CONFDIR/hostapd.log" 2>&1 &
 HOSTAPD_PID=$!
 echo $HOSTAPD_PID > $CONFDIR/hostapd.pid
 
-if ! wait $HOSTAPD_PID; then
-    echo -e "\nError: Failed to run hostapd, maybe a program is interfering." >&2
-    if networkmanager_is_running; then
-        echo "If an error like 'n80211: Could not configure driver mode' was thrown" >&2
-        echo "try running the following before starting create_ap:" >&2
-        if [[ $NM_OLDER_VERSION -eq 1 ]]; then
-            echo "    nmcli nm wifi off" >&2
-        else
-            echo "    nmcli r wifi off" >&2
+sleep 1
+if ! kill -0 $HOSTAPD_PID 2>/dev/null; then
+    if ! wait $HOSTAPD_PID; then
+        echo -e "\nError: Failed to run hostapd, maybe a program is interfering." >&2
+        if networkmanager_is_running; then
+            echo "If an error like 'n80211: Could not configure driver mode' was thrown" >&2
+            echo "try running the following before starting create_ap:" >&2
+            if [[ $NM_OLDER_VERSION -eq 1 ]]; then
+                echo "    nmcli nm wifi off" >&2
+            else
+                echo "    nmcli r wifi off" >&2
+            fi
+            echo "    rfkill unblock wlan" >&2
         fi
-        echo "    rfkill unblock wlan" >&2
+        echo "See $CONFDIR/hostapd.log for details." >&2
+        die
     fi
-    die
+fi
+
+{ printf 'AP-ENABLED\n'; } 2>/dev/null || true
+exec >/dev/null 2>&1
+
+if ! wait $HOSTAPD_PID; then
+    exit 1
 fi
 
 clean_exit

--- a/src/scripts/wihotspot
+++ b/src/scripts/wihotspot
@@ -1,4 +1,13 @@
 #!/bin/sh
 
-# Start wihotspot-gui
-/usr/bin/wihotspot-gui
+# GUI apps should run as the desktop user; only create_ap needs root (via pkexec).
+if [ "$(id -u)" -eq 0 ] && [ -n "${SUDO_USER:-}" ] && [ "$SUDO_USER" != "root" ]; then
+    SUDO_HOME=$(getent passwd "$SUDO_USER" | cut -d: -f6)
+    exec sudo -u "$SUDO_USER" env \
+        DISPLAY="${DISPLAY:-:0}" \
+        XAUTHORITY="${XAUTHORITY:-$SUDO_HOME/.Xauthority}" \
+        DBUS_SESSION_BUS_ADDRESS="${DBUS_SESSION_BUS_ADDRESS:-unix:path=/run/user/$(id -u "$SUDO_USER")/bus}" \
+        /usr/bin/wihotspot-gui "$@"
+fi
+
+exec /usr/bin/wihotspot-gui "$@"

--- a/src/ui/h_prop.c
+++ b/src/ui/h_prop.c
@@ -31,6 +31,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <unistd.h>
+#include <glob.h>
 //#include <libconfig.h>
 
 #include "h_prop.h"
@@ -47,6 +49,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define MKCONFIG "--mkconfig"
 #define LOAD_CONFIG "--config"
 #define STOP "--stop"
+#define SHOW_INFO "--show-info"
 
 
 static char cmd_start[BUFSIZE];
@@ -63,9 +66,18 @@ static char accepted_macs[BUFSIZE];
 static const char* g_ssid=NULL;
 static const char* g_pass=NULL;
 
-static char* qr_image_path;
-
 //config_t cfg;
+
+static char create_ap_invocation[64];
+
+static const char *get_create_ap_invocation(void) {
+    if (geteuid() == 0) {
+        snprintf(create_ap_invocation, sizeof(create_ap_invocation), "%s", CREATE_AP);
+    } else {
+        snprintf(create_ap_invocation, sizeof(create_ap_invocation), "%s %s", SUDO, CREATE_AP);
+    }
+    return create_ap_invocation;
+}
 
 static int parse_output(const char *cmd) {
 
@@ -93,7 +105,8 @@ static int parse_output(const char *cmd) {
 
 const char *build_wh_start_command(char *iface_src, char *iface_dest, char *ssid, char *pass) {
 
-    snprintf(cmd_start, BUFSIZE, "%s %s %s %s %s %s", SUDO, CREATE_AP, iface_src, iface_dest, ssid, pass);
+    snprintf(cmd_start, BUFSIZE, "%s %s %s %s %s", get_create_ap_invocation(),
+             iface_src, iface_dest, ssid, pass);
 
     return cmd_start;
 }
@@ -103,7 +116,9 @@ const char *build_wh_mkconfig_command(ConfigValues* cv){
 
     const char* config_ffile_name=get_config_file(CONFIG_FILE_NAME);
 
-    snprintf(cmd_mkconfig, BUFSIZE, "%s %s %s %s '%s' '%s' %s %s",SUDO, CREATE_AP, cv->iface_wifi, cv->iface_inet, cv->ssid, cv->pass,MKCONFIG,config_ffile_name);
+    snprintf(cmd_mkconfig, BUFSIZE, "%s %s %s '%s' '%s' %s %s",
+             get_create_ap_invocation(), cv->iface_wifi, cv->iface_inet,
+             cv->ssid, cv->pass, MKCONFIG, config_ffile_name);
 
     if(cv->freq!=NULL){
         strcat(cmd_mkconfig," --freq-band ");
@@ -163,7 +178,8 @@ const char *build_wh_mkconfig_command(ConfigValues* cv){
 
 const char *build_wh_from_config(){
 
-    snprintf(cmd_config, BUFSIZE, "%s %s %s %s", SUDO, CREATE_AP,LOAD_CONFIG,get_config_file(CONFIG_FILE_NAME));
+    snprintf(cmd_config, BUFSIZE, "%s %s %s", get_create_ap_invocation(),
+             LOAD_CONFIG, get_config_file(CONFIG_FILE_NAME));
     return cmd_config;
 
 }
@@ -173,8 +189,8 @@ int startShell(const char *cmd) {
 }
 
 
-const char* build_kill_create_ap_command(char* pid){
-    snprintf(cmd_kill, BUFSIZE, "%s %s %s %s", SUDO, CREATE_AP,STOP,pid);
+const char* build_kill_create_ap_command(char* id){
+    snprintf(cmd_kill, BUFSIZE, "%s %s %s", get_create_ap_invocation(), STOP, id);
     return cmd_kill;
 }
 
@@ -182,7 +198,10 @@ void write_accepted_macs(char* filename, char* accepted_macs){
 
     printf("mac filter file %s \n",filename);
 
-    snprintf(cmd_write_mac,BUFSIZE,"%s '%s' %s %s","echo", accepted_macs, "| pkexec -u root tee", filename);
+    if (geteuid() == 0)
+        snprintf(cmd_write_mac, BUFSIZE, "echo '%s' | tee %s", accepted_macs, filename);
+    else
+        snprintf(cmd_write_mac, BUFSIZE, "%s '%s' %s %s", "echo", accepted_macs, "| pkexec -u root tee", filename);
     int r=system(cmd_write_mac);
 
 }
@@ -243,7 +262,7 @@ char * read_mac_filter_file(char * filename){
 static int init_get_running(){
 
     char cmd[BUFSIZE];
-    snprintf(cmd, BUFSIZE, "%s %s --list-running",SUDO, CREATE_AP);
+    snprintf(cmd, BUFSIZE, "%s --list-running", get_create_ap_invocation());
 
     FILE *fp;
 
@@ -252,21 +271,484 @@ static int init_get_running(){
         return -1;
     }
 
-    // Clear buffer - Otherwise old one is used
     h_running_info[0] = '\0';
 
-    while (fgets(h_running_info, BUFSIZE, fp) != NULL) {
-        // Do whatever you want here...
-        //printf("%s", h_running_info);
+    while (fgets(h_running_info + strlen(h_running_info),
+                 BUFSIZE - strlen(h_running_info), fp) != NULL) {
+        if (strlen(h_running_info) >= BUFSIZE - 1)
+            break;
     }
 
     if (pclose(fp)) {
-        printf("Command not found or exited with error status\n");
-        return -1;
+        if (h_running_info[0] == '\0') {
+            printf("Command not found or exited with error status\n");
+            return -1;
+        }
     }
 
     return 0;
 
+}
+
+static void parse_running_line(const char *line, RunningHotspot *hotspot) {
+    char buffer[BUFSIZE];
+    char *open_paren;
+    char *close_paren;
+
+    memset(hotspot, 0, sizeof(*hotspot));
+    strncpy(buffer, line, BUFSIZE - 1);
+    buffer[BUFSIZE - 1] = '\0';
+    buffer[strcspn(buffer, "\n")] = 0;
+
+    open_paren = strchr(buffer, '(');
+    if (open_paren != NULL) {
+        close_paren = strchr(open_paren, ')');
+        if (close_paren != NULL) {
+            *close_paren = '\0';
+            snprintf(hotspot->ap_iface, sizeof(hotspot->ap_iface), "%s", open_paren + 1);
+        }
+        *open_paren = '\0';
+    }
+
+    if (sscanf(buffer, "%31s %31s", hotspot->pid, hotspot->phy_iface) < 2) {
+        hotspot->pid[0] = '\0';
+        return;
+    }
+
+    if (hotspot->ap_iface[0] == '\0')
+        snprintf(hotspot->ap_iface, sizeof(hotspot->ap_iface), "%s", hotspot->phy_iface);
+}
+
+int get_running_hotspots(RunningHotspot **hotspots, int *count) {
+    char *line;
+    char *saveptr;
+    char buffer[BUFSIZE];
+    int capacity = 4;
+    int n = 0;
+    RunningHotspot *list;
+
+    *hotspots = NULL;
+    *count = 0;
+
+    if (init_get_running() != 0 || h_running_info[0] == '\0')
+        return -1;
+
+    list = malloc(capacity * sizeof(RunningHotspot));
+    if (list == NULL)
+        return -1;
+
+    strncpy(buffer, h_running_info, BUFSIZE - 1);
+    buffer[BUFSIZE - 1] = '\0';
+
+    line = strtok_r(buffer, "\n", &saveptr);
+    while (line != NULL) {
+        while (*line == ' ' || *line == '\t')
+            line++;
+
+        if (*line != '\0') {
+            if (n >= capacity) {
+                capacity *= 2;
+                RunningHotspot *grown = realloc(list, capacity * sizeof(RunningHotspot));
+                if (grown == NULL) {
+                    free(list);
+                    return -1;
+                }
+                list = grown;
+            }
+            parse_running_line(line, &list[n]);
+            if (list[n].pid[0] != '\0')
+                n++;
+        }
+        line = strtok_r(NULL, "\n", &saveptr);
+    }
+
+    if (n == 0) {
+        free(list);
+        return 0;
+    }
+
+    *hotspots = list;
+    *count = n;
+    return 0;
+}
+
+void free_running_hotspots(RunningHotspot *hotspots) {
+    free(hotspots);
+}
+
+static int is_live_pid_str(const char *pid_str) {
+    char path[64];
+
+    if (pid_str == NULL || pid_str[0] == '\0')
+        return 0;
+
+    snprintf(path, sizeof(path), "/proc/%s", pid_str);
+    return access(path, F_OK) == 0;
+}
+
+static int read_text_file(const char *path, char *buf, size_t size) {
+    FILE *fp;
+
+    if (size == 0)
+        return -1;
+
+    buf[0] = '\0';
+    fp = fopen(path, "r");
+    if (fp == NULL)
+        return -1;
+
+    if (fgets(buf, (int) size, fp) == NULL) {
+        fclose(fp);
+        return -1;
+    }
+
+    fclose(fp);
+    buf[strcspn(buf, "\n")] = '\0';
+    return 0;
+}
+
+static int find_running_confdir(const char *id, char *confdir_out, size_t confdir_size) {
+    glob_t g;
+    size_t i;
+    char pid[32];
+
+    if (id == NULL || id[0] == '\0' || confdir_out == NULL || confdir_size == 0)
+        return -1;
+
+    if (glob("/tmp/create_ap.*", GLOB_ONLYDIR, NULL, &g) != 0)
+        return -1;
+
+    for (i = 0; i < g.gl_pathc; i++) {
+        char pid_path[BUFSIZE];
+
+        snprintf(pid_path, sizeof(pid_path), "%s/pid", g.gl_pathv[i]);
+        if (read_text_file(pid_path, pid, sizeof(pid)) != 0)
+            continue;
+        if (!is_live_pid_str(pid))
+            continue;
+
+        if (strcmp(id, pid) == 0) {
+            snprintf(confdir_out, confdir_size, "%s", g.gl_pathv[i]);
+            globfree(&g);
+            return 0;
+        }
+
+        if (strncmp(g.gl_pathv[i], "/tmp/create_ap.", 15) == 0) {
+            const char *p = g.gl_pathv[i] + 15;
+            const char *dot = strstr(p, ".conf.");
+            if (dot != NULL) {
+                char iface[32];
+                size_t len = (size_t) (dot - p);
+
+                if (len > 0 && len < sizeof(iface)) {
+                    memcpy(iface, p, len);
+                    iface[len] = '\0';
+                    if (strcmp(id, iface) == 0) {
+                        snprintf(confdir_out, confdir_size, "%s", g.gl_pathv[i]);
+                        globfree(&g);
+                        return 0;
+                    }
+                }
+            }
+        }
+    }
+
+    globfree(&g);
+    return -1;
+}
+
+static void set_key_value(const char *line, const char *key, char *dest, size_t dest_size) {
+    size_t key_len;
+
+    if (dest == NULL || dest_size == 0 || line == NULL || key == NULL)
+        return;
+
+    key_len = strlen(key);
+    if (strncmp(line, key, key_len) == 0 && line[key_len] == '=')
+        snprintf(dest, dest_size, "%s", line + key_len + 1);
+}
+
+static void set_encryption_label(HotspotDetails *details, const char *wpa,
+                                 const char *key_mgmt, const char *passphrase,
+                                 const char *psk) {
+    if ((passphrase == NULL || passphrase[0] == '\0')
+        && (psk == NULL || psk[0] == '\0')) {
+        snprintf(details->encryption, sizeof(details->encryption), "Open");
+        return;
+    }
+
+    if (key_mgmt != NULL && strstr(key_mgmt, "SAE") != NULL) {
+        snprintf(details->encryption, sizeof(details->encryption), "WPA2/WPA3");
+        return;
+    }
+
+    if (wpa != NULL && strcmp(wpa, "3") == 0) {
+        snprintf(details->encryption, sizeof(details->encryption), "WPA3");
+        return;
+    }
+
+    if (wpa != NULL && strcmp(wpa, "2") == 0) {
+        snprintf(details->encryption, sizeof(details->encryption), "WPA2-PSK");
+        return;
+    }
+
+    if (wpa != NULL && strcmp(wpa, "1") == 0) {
+        snprintf(details->encryption, sizeof(details->encryption), "WPA-PSK");
+        return;
+    }
+
+    if (psk != NULL && psk[0] != '\0')
+        snprintf(details->encryption, sizeof(details->encryption), "WPA-PSK (hex)");
+    else
+        snprintf(details->encryption, sizeof(details->encryption), "WPA-PSK");
+}
+
+static void parse_hostapd_conf(const char *path, HotspotDetails *details) {
+    FILE *fp;
+    char line[BUFSIZE];
+    char wpa[8] = "";
+    char key_mgmt[64] = "";
+    char passphrase[128] = "";
+    char psk[128] = "";
+    char hw_mode[8] = "";
+    char hidden[8] = "";
+
+    fp = fopen(path, "r");
+    if (fp == NULL)
+        return;
+
+    while (fgets(line, sizeof(line), fp) != NULL) {
+        line[strcspn(line, "\n")] = '\0';
+        set_key_value(line, "ssid", details->ssid, sizeof(details->ssid));
+        set_key_value(line, "interface", details->ap_iface, sizeof(details->ap_iface));
+        set_key_value(line, "channel", details->channel, sizeof(details->channel));
+        set_key_value(line, "wpa", wpa, sizeof(wpa));
+        set_key_value(line, "wpa_key_mgmt", key_mgmt, sizeof(key_mgmt));
+        set_key_value(line, "wpa_passphrase", passphrase, sizeof(passphrase));
+        set_key_value(line, "wpa_psk", psk, sizeof(psk));
+        set_key_value(line, "hw_mode", hw_mode, sizeof(hw_mode));
+        set_key_value(line, "ignore_broadcast_ssid", hidden, sizeof(hidden));
+    }
+
+    fclose(fp);
+
+    if (passphrase[0] != '\0')
+        snprintf(details->passphrase, sizeof(details->passphrase), "%s", passphrase);
+    else if (psk[0] != '\0')
+        snprintf(details->passphrase, sizeof(details->passphrase), "%s", psk);
+
+    if (strcmp(hw_mode, "a") == 0)
+        snprintf(details->band, sizeof(details->band), "5 GHz");
+    else if (strcmp(hw_mode, "g") == 0)
+        snprintf(details->band, sizeof(details->band), "2.4 GHz");
+    else
+        snprintf(details->band, sizeof(details->band), "Unknown");
+
+    if (strcmp(hidden, "1") == 0)
+        snprintf(details->hidden, sizeof(details->hidden), "Yes");
+    else
+        snprintf(details->hidden, sizeof(details->hidden), "No");
+
+    set_encryption_label(details, wpa, key_mgmt, passphrase, psk);
+}
+
+static void parse_dnsmasq_conf(const char *path, HotspotDetails *details) {
+    FILE *fp;
+    char line[BUFSIZE];
+
+    fp = fopen(path, "r");
+    if (fp == NULL)
+        return;
+
+    while (fgets(line, sizeof(line), fp) != NULL) {
+        line[strcspn(line, "\n")] = '\0';
+        set_key_value(line, "listen-address", details->gateway, sizeof(details->gateway));
+    }
+
+    fclose(fp);
+}
+
+static int join_conf_path(char *dest, size_t dest_size, const char *confdir, const char *suffix) {
+    size_t dir_len;
+    size_t suffix_len;
+
+    if (dest == NULL || confdir == NULL || suffix == NULL || dest_size == 0)
+        return -1;
+
+    dir_len = strlen(confdir);
+    suffix_len = strlen(suffix);
+    if (dir_len + suffix_len + 1 > dest_size)
+        return -1;
+
+    memcpy(dest, confdir, dir_len);
+    memcpy(dest + dir_len, suffix, suffix_len + 1);
+    return 0;
+}
+
+static void apply_show_info_line(const char *line, HotspotDetails *details) {
+    const char *value;
+
+    if (line == NULL || details == NULL)
+        return;
+
+    value = strchr(line, '=');
+    if (value == NULL)
+        return;
+    value++;
+
+    if (strncmp(line, "PID=", 4) == 0)
+        snprintf(details->pid, sizeof(details->pid), "%s", value);
+    else if (strncmp(line, "PHY_IFACE=", 10) == 0)
+        snprintf(details->phy_iface, sizeof(details->phy_iface), "%s", value);
+    else if (strncmp(line, "AP_IFACE=", 9) == 0)
+        snprintf(details->ap_iface, sizeof(details->ap_iface), "%s", value);
+    else if (strncmp(line, "INTERNET_IFACE=", 15) == 0)
+        snprintf(details->internet_iface, sizeof(details->internet_iface), "%s", value);
+    else if (strncmp(line, "SSID=", 5) == 0)
+        snprintf(details->ssid, sizeof(details->ssid), "%s", value);
+    else if (strncmp(line, "PASSPHRASE=", 11) == 0)
+        snprintf(details->passphrase, sizeof(details->passphrase), "%s", value);
+    else if (strncmp(line, "ENCRYPTION=", 11) == 0)
+        snprintf(details->encryption, sizeof(details->encryption), "%s", value);
+    else if (strncmp(line, "GATEWAY=", 8) == 0)
+        snprintf(details->gateway, sizeof(details->gateway), "%s", value);
+    else if (strncmp(line, "CHANNEL=", 8) == 0)
+        snprintf(details->channel, sizeof(details->channel), "%s", value);
+    else if (strncmp(line, "BAND=", 5) == 0)
+        snprintf(details->band, sizeof(details->band), "%s", value);
+    else if (strncmp(line, "HIDDEN=", 7) == 0)
+        snprintf(details->hidden, sizeof(details->hidden), "%s", value);
+}
+
+static int fetch_hotspot_details_via_create_ap(const char *id, HotspotDetails *details) {
+    char cmd[BUFSIZE];
+    char line[BUFSIZE];
+    FILE *fp;
+
+    snprintf(cmd, BUFSIZE, "%s %s %s", get_create_ap_invocation(), SHOW_INFO, id);
+
+    fp = popen(cmd, "r");
+    if (fp == NULL)
+        return -1;
+
+    while (fgets(line, sizeof(line), fp) != NULL) {
+        line[strcspn(line, "\n")] = 0;
+        apply_show_info_line(line, details);
+    }
+
+    pclose(fp);
+    return 0;
+}
+
+static void fill_details_from_saved_config(HotspotDetails *details) {
+    ConfigValues *cv;
+
+    if (read_config_file() != READ_CONFIG_FILE_SUCCESS)
+        return;
+
+    cv = getConfigValues();
+    if (cv == NULL)
+        return;
+
+    if (details->ssid[0] == '\0' && cv->ssid != NULL && cv->ssid[0] != '\0')
+        snprintf(details->ssid, sizeof(details->ssid), "%s", cv->ssid);
+
+    if ((details->passphrase[0] == '\0' || strcmp(details->passphrase, "(none)") == 0)
+        && cv->pass != NULL && cv->pass[0] != '\0')
+        snprintf(details->passphrase, sizeof(details->passphrase), "%s", cv->pass);
+
+    if (details->gateway[0] == '\0' && cv->gateway != NULL && cv->gateway[0] != '\0')
+        snprintf(details->gateway, sizeof(details->gateway), "%s", cv->gateway);
+
+    if (details->channel[0] == '\0' && cv->channel != NULL && cv->channel[0] != '\0')
+        snprintf(details->channel, sizeof(details->channel), "%s", cv->channel);
+
+    if (details->band[0] == '\0' && cv->freq != NULL) {
+        if (strcmp(cv->freq, "5") == 0)
+            snprintf(details->band, sizeof(details->band), "5 GHz");
+        else if (strcmp(cv->freq, "2.4") == 0)
+            snprintf(details->band, sizeof(details->band), "2.4 GHz");
+    }
+
+    if (details->encryption[0] == '\0') {
+        if (cv->pass != NULL && cv->pass[0] != '\0')
+            snprintf(details->encryption, sizeof(details->encryption), "WPA2-PSK");
+        else
+            snprintf(details->encryption, sizeof(details->encryption), "Open");
+    }
+}
+
+static void finalize_hotspot_details(HotspotDetails *details) {
+    if (details->hidden[0] == '\0')
+        snprintf(details->hidden, sizeof(details->hidden), "No");
+
+    if (details->encryption[0] == '\0') {
+        if (details->passphrase[0] != '\0' && strcmp(details->passphrase, "(none)") != 0)
+            snprintf(details->encryption, sizeof(details->encryption), "WPA2-PSK");
+        else
+            snprintf(details->encryption, sizeof(details->encryption), "Open");
+    }
+
+    if (details->passphrase[0] == '\0')
+        snprintf(details->passphrase, sizeof(details->passphrase), "(none)");
+
+    if (details->internet_iface[0] == '\0')
+        snprintf(details->internet_iface, sizeof(details->internet_iface), "none");
+}
+
+int get_hotspot_details(const char *id, HotspotDetails *details) {
+    char confdir[512];
+    char path[512];
+
+    if (details == NULL)
+        return -1;
+
+    memset(details, 0, sizeof(*details));
+
+    if (find_running_confdir(id, confdir, sizeof(confdir)) != 0)
+        return -1;
+
+    if (join_conf_path(path, sizeof(path), confdir, "/pid") != 0)
+        return -1;
+    read_text_file(path, details->pid, sizeof(details->pid));
+
+    if (strncmp(confdir, "/tmp/create_ap.", 15) == 0) {
+        const char *p = confdir + 15;
+        const char *dot = strstr(p, ".conf.");
+        if (dot != NULL) {
+            size_t len = (size_t) (dot - p);
+            if (len > 0 && len < sizeof(details->phy_iface)) {
+                memcpy(details->phy_iface, p, len);
+                details->phy_iface[len] = '\0';
+            }
+        }
+    }
+
+    if (join_conf_path(path, sizeof(path), confdir, "/wifi_iface") != 0)
+        return -1;
+    read_text_file(path, details->ap_iface, sizeof(details->ap_iface));
+
+    if (join_conf_path(path, sizeof(path), confdir, "/nat_internet_iface") != 0)
+        return -1;
+    if (read_text_file(path, details->internet_iface, sizeof(details->internet_iface)) != 0)
+        snprintf(details->internet_iface, sizeof(details->internet_iface), "none");
+
+    if (join_conf_path(path, sizeof(path), confdir, "/hostapd.conf") != 0)
+        return -1;
+    parse_hostapd_conf(path, details);
+
+    if (join_conf_path(path, sizeof(path), confdir, "/dnsmasq.conf") != 0)
+        return -1;
+    parse_dnsmasq_conf(path, details);
+
+    if (details->ssid[0] == '\0' || details->encryption[0] == '\0')
+        fetch_hotspot_details_via_create_ap(id, details);
+
+    if (details->ssid[0] == '\0')
+        fill_details_from_saved_config(details);
+
+    finalize_hotspot_details(details);
+    return 0;
 }
 
 
@@ -436,44 +918,35 @@ char** get_wifi_interface_list(int *length){
 
 }
 
+static char qr_image_path[128];
+
 char* generate_qr_image(char* ssid,char* type,char *password){
     char cmd[BUFSIZE];
+    const char *ssid_safe = ssid ? ssid : "";
+    const char *type_safe = type ? type : "WPA";
+    const char *pass_safe = password ? password : "";
 
-    qr_image_path = "/tmp/wihotspot_qr.png";
+    snprintf(qr_image_path, sizeof(qr_image_path), "/tmp/wihotspot_qr_%d.png", getuid());
+    unlink(qr_image_path);
 
-    // snprintf(cmd, BUFSIZE, "%s -s 10 -d 256 -o %s 'WIFI:S:%s;T:%s;P:%s;;' ","qrencode",qr_image_path, ssid,type,password);
+    if (ssid_safe[0] == '\0')
+        return NULL;
 
-    // FILE *fp;
+    if (strcmp(type_safe, "nopass") == 0)
+        snprintf(cmd, BUFSIZE, "WIFI:T:nopass;S:%s;;", ssid_safe);
+    else
+        snprintf(cmd, BUFSIZE, "WIFI:T:%s;S:%s;P:%s;;", type_safe, ssid_safe, pass_safe);
 
-    // char temp_buff[1048];
+    if (qr_to_png(cmd, qr_image_path) != 0)
+        return NULL;
 
-    // if ((fp = popen(cmd, "r")) == NULL) {
-    //     printf("Error opening pipe!\n");
-        
-    // }
-
-
-    // while (fgets(temp_buff, sizeof(temp_buff), fp) != NULL) {
-    
-    //     printf("%s", temp_buff);
-    // }
-
-    // if (pclose(fp)) {
-    //     printf("Error executing qrencode\n");
-        
-    // }
-
-    snprintf(cmd, BUFSIZE, "WIFI:S:%s;T:%s;P:%s;;",ssid,type,password);
-
-    qr_to_png(cmd,qr_image_path);
-    
     return qr_image_path;
 }
 
 Node get_connected_devices(char *PID)
 {
     char cmd[BUFSIZE];
-    snprintf(cmd, BUFSIZE, "%s %s --list-clients %s", SUDO, CREATE_AP, PID);
+    snprintf(cmd, BUFSIZE, "%s --list-clients %s", get_create_ap_invocation(), PID);
     FILE *fp;
     Node l = (struct Device *)malloc(sizeof(struct Device));
     Position head = l;

--- a/src/ui/h_prop.h
+++ b/src/ui/h_prop.h
@@ -47,6 +47,26 @@ struct Device
 typedef PtrToNode Position;
 typedef PtrToNode Node;
 
+typedef struct {
+    char pid[32];
+    char phy_iface[32];
+    char ap_iface[64];
+} RunningHotspot;
+
+typedef struct {
+    char pid[32];
+    char phy_iface[32];
+    char ap_iface[64];
+    char internet_iface[32];
+    char ssid[64];
+    char passphrase[128];
+    char encryption[64];
+    char gateway[32];
+    char channel[16];
+    char band[16];
+    char hidden[16];
+} HotspotDetails;
+
 static int parse_output(const char *);
 
 const char *build_wh_start_command(char *, char *, char *, char *);
@@ -57,6 +77,9 @@ int startShell(const char *);
 int write_config(char *);
 
 int get_h_running_info(char** a);
+int get_running_hotspots(RunningHotspot **hotspots, int *count);
+void free_running_hotspots(RunningHotspot *hotspots);
+int get_hotspot_details(const char *id, HotspotDetails *details);
 static int init_get_running();
 
 static int init_get_interface_list();

--- a/src/ui/qr_ui.c
+++ b/src/ui/qr_ui.c
@@ -31,29 +31,44 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #include <gtk/gtk.h>
+#include <unistd.h>
 #include "qr_ui.h"
 
-static GtkBuilder *builder;
-static GError *error = NULL;
+void open_qr(GtkWidget *widget, gpointer data, char *image_path) {
+    GtkBuilder *builder;
+    GtkWidget *dialog;
+    GtkImage *qr_image;
+    GError *error = NULL;
+    GtkWidget *toplevel;
 
-void open_qr(GtkWidget *widget, gpointer root,char* image_path) {
+    (void)data;
+
+    if (image_path == NULL || access(image_path, R_OK) != 0)
+        return;
 
     builder = gtk_builder_new();
-    //Load ui description from built resource - need to generate compiled source with glib-compile-resource
-    gtk_builder_add_from_resource(builder,"/org/gtk/wihotspot/qr.glade",&error);
+    if (!gtk_builder_add_from_resource(builder, "/org/gtk/wihotspot/qr.glade", &error)) {
+        g_warning("Failed to load QR dialog: %s", error ? error->message : "unknown");
+        g_clear_error(&error);
+        g_object_unref(builder);
+        return;
+    }
 
-    root = gtk_builder_get_object(builder, "dialog_qr");
+    dialog = GTK_WIDGET(gtk_builder_get_object(builder, "dialog_qr"));
+    qr_image = GTK_IMAGE(gtk_builder_get_object(builder, "image_qr"));
+    if (dialog == NULL || qr_image == NULL) {
+        g_object_unref(builder);
+        return;
+    }
 
-    GtkImage* qr_image = (GtkImage *) gtk_builder_get_object(builder, "image_qr");
+    if (widget != NULL) {
+        toplevel = gtk_widget_get_toplevel(widget);
+        if (GTK_IS_WINDOW(toplevel))
+            gtk_window_set_transient_for(GTK_WINDOW(dialog), GTK_WINDOW(toplevel));
+    }
 
-    gtk_image_set_from_file(qr_image,image_path);
-
-    GtkDialog* dialog= GTK_DIALOG(root);
-    
+    gtk_image_set_from_file(qr_image, image_path);
     gtk_dialog_run(GTK_DIALOG(dialog));
-
-    gtk_widget_destroy(GTK_WIDGET( dialog));
-    
-    g_signal_connect (dialog, "destroy", G_CALLBACK(gtk_main_quit), NULL);
-
+    gtk_widget_destroy(dialog);
+    g_object_unref(builder);
 }

--- a/src/ui/qrgen.cpp
+++ b/src/ui/qrgen.cpp
@@ -69,12 +69,23 @@ static unsigned int bg_color[4] = {255, 255, 255, 255};
 // return 0;
 // }
 
-void qr_to_png(const char *qrstring,const char *outfile){
-
+int qr_to_png(const char *qrstring,const char *outfile){
     QRcode *myqrcode;
-        myqrcode = QRcode_encodeString(qrstring, 4, QR_ECLEVEL_H, QR_MODE_8,1);
-        writePNG(myqrcode,outfile);
+
+    if (qrstring == NULL || outfile == NULL)
+        return -1;
+
+    myqrcode = QRcode_encodeString(qrstring, 4, QR_ECLEVEL_H, QR_MODE_8, 1);
+    if (myqrcode == NULL)
+        return -1;
+
+    if (writePNG(myqrcode, outfile) != 0) {
         QRcode_free(myqrcode);
+        return -1;
+    }
+
+    QRcode_free(myqrcode);
+    return 0;
 }
 
 
@@ -91,11 +102,14 @@ static int writePNG(QRcode *qrcode, const char *outfile)
     int x, y, xx, yy, bit;
     int realwidth;
 
+    if (qrcode == NULL || outfile == NULL)
+        return -1;
+
     realwidth = (qrcode->width + margin * 2) * size;
     row = (unsigned char *)malloc((realwidth + 7) / 8);
     if(row == NULL) {
         fprintf(stderr, "Failed to allocate memory.\n");
-        exit(EXIT_FAILURE);
+        return -1;
     }
 
     if(outfile[0] == '-' && outfile[1] == '\0') {
@@ -105,32 +119,47 @@ static int writePNG(QRcode *qrcode, const char *outfile)
         if(fp == NULL) {
             fprintf(stderr, "Failed to create file: %s\n", outfile);
             perror(NULL);
-            exit(EXIT_FAILURE);
+            free(row);
+            return -1;
         }
     }
 
     png_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
     if(png_ptr == NULL) {
         fprintf(stderr, "Failed to initialize PNG writer.\n");
-        exit(EXIT_FAILURE);
+        if (fp != stdout)
+            fclose(fp);
+        free(row);
+        return -1;
     }
 
     info_ptr = png_create_info_struct(png_ptr);
     if(info_ptr == NULL) {
         fprintf(stderr, "Failed to initialize PNG write.\n");
-        exit(EXIT_FAILURE);
+        png_destroy_write_struct(&png_ptr, NULL);
+        if (fp != stdout)
+            fclose(fp);
+        free(row);
+        return -1;
     }
 
     if(setjmp(png_jmpbuf(png_ptr))) {
         png_destroy_write_struct(&png_ptr, &info_ptr);
+        if (fp != stdout)
+            fclose(fp);
+        free(row);
         fprintf(stderr, "Failed to write PNG image.\n");
-        exit(EXIT_FAILURE);
+        return -1;
     }
 
     palette = (png_colorp) malloc(sizeof(png_color) * 2);
     if(palette == NULL) {
         fprintf(stderr, "Failed to allocate memory.\n");
-        exit(EXIT_FAILURE);
+        png_destroy_write_struct(&png_ptr, &info_ptr);
+        if (fp != stdout)
+            fclose(fp);
+        free(row);
+        return -1;
     }
     palette[0].red   = fg_color[0];
     palette[0].green = fg_color[1];
@@ -195,7 +224,8 @@ for(y=0; y<margin * size; y++) {
 png_write_end(png_ptr, info_ptr);
 png_destroy_write_struct(&png_ptr, &info_ptr);
 
-fclose(fp);
+if (fp != stdout)
+    fclose(fp);
 free(row);
 free(palette);
 

--- a/src/ui/qrgen.h
+++ b/src/ui/qrgen.h
@@ -41,7 +41,7 @@ extern "C" {
 
 static int writePNG(QRcode *qrcode, const char *outfile);
 
-void qr_to_png(const char *qrstring,const char *outfile);
+int qr_to_png(const char *qrstring,const char *outfile);
 
 #ifdef __cplusplus
 }

--- a/src/ui/ui.c
+++ b/src/ui/ui.c
@@ -53,6 +53,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define ERROR_CHANNEL_MSG_5 "Channel must be 1-196"
 #define ERROR_MAC_MSG "Invalid Mac address"
 #define ERROR_GATEWAY_MSG "Invalid gateway IP address"
+#define ERROR_IFACE_MSG "Please select WiFi and Internet interfaces"
+#define ERROR_ALREADY_RUNNING_MSG "Hotspot already running on this WiFi interface. Stop it first."
 
 #define DEFAULT_GATEWAY_IP "192.168.12.1"
 
@@ -105,6 +107,9 @@ GtkProgressBar *progress_bar;
 GtkLabel *label_status;
 GtkLabel *label_input_error;
 
+GtkWidget *hotspot_scrolled;
+GtkWidget *hotspot_listbox;
+
 GtkCssProvider* provider;
 GdkDisplay *display;
 GdkScreen *screen;
@@ -129,36 +134,417 @@ char* running_info[3];
 guint pb_pulse_id;
 static ConfigValues configValues;
 
+static char *get_selected_hotspot_pid(void);
+static void on_hotspot_stop_clicked(GtkButton *button, gpointer user_data);
+static void on_hotspot_qr_clicked(GtkButton *button, gpointer user_data);
+static gboolean wifi_iface_has_running_hotspot(const char *iface);
+static void update_create_button_state(void);
+static void on_combo_wifi_changed(GtkWidget *widget, gpointer data);
+static gboolean idle_refresh_running_info(gpointer data);
+static gboolean idle_apply_running_info(gpointer data);
+static gboolean idle_set_status_label(gpointer data);
+static void *run_stop_shell(void *data);
+static void *fetch_running_info_thread(void *data);
+static void *detach_pclose_thread(void *data);
+static void show_hotspot_info_dialog(GtkWidget *parent, const char *id);
+static gboolean on_hotspot_list_button_press(GtkWidget *widget, GdkEventButton *event, gpointer data);
+
+static void ensure_interface_selection(void) {
+    if (gtk_combo_box_get_active(combo_wifi) < 0 && wifi_iface_list_length > 0)
+        gtk_combo_box_set_active(combo_wifi, 0);
+
+    if (gtk_combo_box_get_active(combo_internet) < 0 && iface_list_length > 0)
+        gtk_combo_box_set_active(combo_internet, 0);
+}
+
+static void clear_hotspot_list(void) {
+    GList *children = gtk_container_get_children(GTK_CONTAINER(hotspot_listbox));
+    GList *iter;
+
+    for (iter = children; iter != NULL; iter = g_list_next(iter))
+        gtk_widget_destroy(GTK_WIDGET(iter->data));
+
+    g_list_free(children);
+}
+
+static void init_hotspot_list_ui(void) {
+    GtkWidget *status_box = gtk_widget_get_parent(GTK_WIDGET(label_status));
+    GtkWidget *list_label = gtk_label_new(NULL);
+
+    gtk_label_set_markup(GTK_LABEL(list_label), "<b>Active Hotspots</b>  <small><i>(right-click for details)</i></small>");
+    gtk_label_set_xalign(GTK_LABEL(list_label), 0.0);
+    gtk_widget_set_margin_start(list_label, 5);
+
+    hotspot_listbox = gtk_list_box_new();
+    gtk_list_box_set_selection_mode(GTK_LIST_BOX(hotspot_listbox), GTK_SELECTION_SINGLE);
+    gtk_widget_set_margin_start(hotspot_listbox, 5);
+    gtk_widget_set_margin_end(hotspot_listbox, 5);
+
+    hotspot_scrolled = gtk_scrolled_window_new(NULL, NULL);
+    gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(hotspot_scrolled),
+                                   GTK_POLICY_AUTOMATIC, GTK_POLICY_AUTOMATIC);
+    gtk_scrolled_window_set_min_content_height(GTK_SCROLLED_WINDOW(hotspot_scrolled), 90);
+    gtk_container_add(GTK_CONTAINER(hotspot_scrolled), hotspot_listbox);
+
+    gtk_box_pack_start(GTK_BOX(status_box), list_label, FALSE, FALSE, 2);
+    gtk_box_pack_start(GTK_BOX(status_box), hotspot_scrolled, FALSE, FALSE, 2);
+    gtk_box_reorder_child(GTK_BOX(status_box), list_label, 0);
+    gtk_box_reorder_child(GTK_BOX(status_box), hotspot_scrolled, 1);
+
+    gtk_widget_add_events(hotspot_listbox, GDK_BUTTON_PRESS_MASK);
+    g_signal_connect(hotspot_listbox, "button-press-event",
+                      G_CALLBACK(on_hotspot_list_button_press), NULL);
+
+    gtk_widget_show_all(status_box);
+}
+
+static void show_hotspot_info_dialog(GtkWidget *parent, const char *id) {
+    HotspotDetails details;
+    GtkWidget *dialog;
+    GtkWidget *content;
+    GtkWidget *toplevel;
+    char body[4096];
+
+    if (get_hotspot_details(id, &details) != 0) {
+        toplevel = parent != NULL ? gtk_widget_get_toplevel(parent) : NULL;
+        dialog = gtk_message_dialog_new(GTK_IS_WINDOW(toplevel) ? GTK_WINDOW(toplevel) : NULL,
+                                        GTK_DIALOG_MODAL,
+                                        GTK_MESSAGE_WARNING,
+                                        GTK_BUTTONS_OK,
+                                        "Could not read hotspot details");
+        gtk_message_dialog_format_secondary_text(GTK_MESSAGE_DIALOG(dialog),
+            "Hotspot data may be unavailable for %s.", id ? id : "selection");
+        gtk_dialog_run(GTK_DIALOG(dialog));
+        gtk_widget_destroy(dialog);
+        return;
+    }
+
+    snprintf(body, sizeof(body),
+             "SSID: %s\n"
+             "Password: %s\n"
+             "Security: %s\n"
+             "Hidden: %s\n"
+             "Channel: %s\n"
+             "Band: %s\n"
+             "Gateway: %s\n"
+             "WiFi interface: %s\n"
+             "AP interface: %s\n"
+             "Internet sharing: %s\n"
+             "PID: %s",
+             details.ssid[0] ? details.ssid : "(unknown)",
+             details.passphrase,
+             details.encryption,
+             details.hidden,
+             details.channel[0] ? details.channel : "(unknown)",
+             details.band,
+             details.gateway[0] ? details.gateway : "(unknown)",
+             details.phy_iface[0] ? details.phy_iface : "(unknown)",
+             details.ap_iface[0] ? details.ap_iface : "(unknown)",
+             details.internet_iface,
+             details.pid);
+
+    toplevel = parent != NULL ? gtk_widget_get_toplevel(parent) : NULL;
+    dialog = gtk_message_dialog_new(GTK_IS_WINDOW(toplevel) ? GTK_WINDOW(toplevel) : NULL,
+                                    GTK_DIALOG_MODAL,
+                                    GTK_MESSAGE_INFO,
+                                    GTK_BUTTONS_OK,
+                                    "Hotspot: %s",
+                                    details.ssid[0] ? details.ssid : id);
+    content = gtk_message_dialog_get_message_area(GTK_MESSAGE_DIALOG(dialog));
+    gtk_container_set_border_width(GTK_CONTAINER(content), 12);
+    gtk_message_dialog_format_secondary_text(GTK_MESSAGE_DIALOG(dialog), "%s", body);
+    gtk_dialog_run(GTK_DIALOG(dialog));
+    gtk_widget_destroy(dialog);
+}
+
+static gboolean on_hotspot_list_button_press(GtkWidget *widget, GdkEventButton *event, gpointer data) {
+    GtkListBoxRow *row;
+    GtkWidget *row_box;
+    const char *stop_id;
+
+    (void)data;
+
+    if (event->type != GDK_BUTTON_PRESS || event->button != 3)
+        return FALSE;
+
+    row = gtk_list_box_get_row_at_y(GTK_LIST_BOX(widget), (gint) event->y);
+    if (row == NULL)
+        return FALSE;
+
+    gtk_list_box_select_row(GTK_LIST_BOX(widget), row);
+    row_box = gtk_bin_get_child(GTK_BIN(row));
+    stop_id = g_object_get_data(G_OBJECT(row_box), "hotspot-iface");
+    if (stop_id == NULL)
+        stop_id = g_object_get_data(G_OBJECT(row_box), "hotspot-pid");
+    if (stop_id == NULL)
+        return FALSE;
+
+    show_hotspot_info_dialog(widget, stop_id);
+    return TRUE;
+}
+
+static gboolean wifi_iface_has_running_hotspot(const char *iface) {
+    RunningHotspot *hotspots = NULL;
+    int count = 0;
+    int i;
+    gboolean found = FALSE;
+
+    if (iface == NULL || iface[0] == '\0')
+        return FALSE;
+
+    if (get_running_hotspots(&hotspots, &count) != 0) {
+        free_running_hotspots(hotspots);
+        return FALSE;
+    }
+
+    for (i = 0; i < count; i++) {
+        if (strcmp(hotspots[i].phy_iface, iface) == 0) {
+            found = TRUE;
+            break;
+        }
+    }
+
+    free_running_hotspots(hotspots);
+    return found;
+}
+
+static void update_create_button_state(void) {
+    gchar *wifi = NULL;
+    gboolean can_create = FALSE;
+
+    if (gtk_combo_box_get_active(combo_wifi) >= 0) {
+        wifi = gtk_combo_box_text_get_active_text(GTK_COMBO_BOX_TEXT(combo_wifi));
+        if (wifi != NULL && wifi[0] != '\0' && !wifi_iface_has_running_hotspot(wifi))
+            can_create = TRUE;
+    }
+
+    gtk_widget_set_sensitive(GTK_WIDGET(button_create_hp), can_create);
+    g_free(wifi);
+}
+
+static void on_combo_wifi_changed(GtkWidget *widget, gpointer data) {
+    (void)widget;
+    (void)data;
+    update_create_button_state();
+}
+
+static char *get_stop_target_id(void) {
+    GtkListBoxRow *row = gtk_list_box_get_selected_row(GTK_LIST_BOX(hotspot_listbox));
+
+    if (row == NULL)
+        return NULL;
+
+    GtkWidget *row_box = gtk_bin_get_child(GTK_BIN(row));
+    const char *iface = g_object_get_data(G_OBJECT(row_box), "hotspot-iface");
+    const char *pid = g_object_get_data(G_OBJECT(row_box), "hotspot-pid");
+
+    if (iface != NULL && iface[0] != '\0')
+        return g_strdup(iface);
+    if (pid != NULL && pid[0] != '\0')
+        return g_strdup(pid);
+
+    return NULL;
+}
+
+static void begin_stop_hotspot(const char *stop_id) {
+    char *stop_id_copy;
+
+    if (stop_id == NULL || stop_id[0] == '\0') {
+        set_error_text("Select a hotspot in the Active Hotspots list to stop");
+        return;
+    }
+
+    stop_id_copy = g_strdup(stop_id);
+    gtk_label_set_label(label_status, "Stopping ...");
+    set_error_text("");
+    start_pb_pulse();
+    lock_all_views(TRUE);
+    g_thread_new("stop_hp", run_stop_shell, stop_id_copy);
+}
+
+static char *get_selected_hotspot_pid(void) {
+    return get_stop_target_id();
+}
+
+static void on_hotspot_stop_clicked(GtkButton *button, gpointer user_data) {
+    const char *stop_id = g_object_get_data(G_OBJECT(button), "hotspot-iface");
+
+    (void)user_data;
+
+    if (stop_id == NULL)
+        stop_id = g_object_get_data(G_OBJECT(button), "hotspot-pid");
+    begin_stop_hotspot(stop_id);
+}
+
+static void show_qr_for_hotspot(GtkWidget *widget, const char *hotspot_id) {
+    HotspotDetails details;
+    const char *qr_type;
+    const char *pass;
+    char *image_path;
+
+    if (hotspot_id == NULL || hotspot_id[0] == '\0') {
+        set_error_text("No hotspot selected for QR code");
+        return;
+    }
+
+    if (get_hotspot_details(hotspot_id, &details) != 0) {
+        set_error_text("Could not read hotspot details for QR code");
+        return;
+    }
+
+    if (details.ssid[0] == '\0') {
+        set_error_text("SSID is required to generate QR code");
+        return;
+    }
+
+    if (strcmp(details.encryption, "Open") == 0
+        || strcmp(details.passphrase, "(none)") == 0
+        || details.passphrase[0] == '\0') {
+        pass = "";
+        qr_type = "nopass";
+    } else {
+        pass = details.passphrase;
+        qr_type = "WPA";
+    }
+
+    image_path = generate_qr_image((char *) details.ssid, (char *) qr_type, (char *) pass);
+    if (image_path == NULL) {
+        set_error_text("Failed to generate QR code");
+        return;
+    }
+
+    set_error_text("");
+    open_qr(widget, NULL, image_path);
+}
+
+static void on_hotspot_qr_clicked(GtkButton *button, gpointer user_data) {
+    const char *hotspot_id = g_object_get_data(G_OBJECT(button), "hotspot-iface");
+
+    (void)user_data;
+
+    if (hotspot_id == NULL)
+        hotspot_id = g_object_get_data(G_OBJECT(button), "hotspot-pid");
+    show_qr_for_hotspot(GTK_WIDGET(button), hotspot_id);
+}
+
+static void *run_stop_shell(void *data) {
+    char *stop_id = data;
+
+    startShell(build_kill_create_ap_command(stop_id));
+    g_free(stop_id);
+    g_idle_add(idle_refresh_running_info, NULL);
+    return NULL;
+}
+
+static void add_hotspot_row(const RunningHotspot *hotspot) {
+    GtkWidget *row_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 8);
+    GtkWidget *info = gtk_label_new(NULL);
+    GtkWidget *qr_btn = gtk_button_new_with_label("QR");
+    GtkWidget *stop_btn = gtk_button_new_with_label("Stop");
+    char text[BUFSIZE];
+    char *pid_copy = g_strdup(hotspot->pid);
+    char *iface_copy = g_strdup(hotspot->phy_iface);
+
+    snprintf(text, BUFSIZE, "PID %s   |   WiFi: %s   |   AP: %s",
+             hotspot->pid, hotspot->phy_iface, hotspot->ap_iface);
+    gtk_label_set_text(GTK_LABEL(info), text);
+    gtk_label_set_xalign(GTK_LABEL(info), 0.0);
+    gtk_widget_set_hexpand(info, TRUE);
+
+    g_object_set_data_full(G_OBJECT(row_box), "hotspot-pid", pid_copy, g_free);
+    g_object_set_data(G_OBJECT(row_box), "hotspot-iface", iface_copy);
+    g_object_set_data(G_OBJECT(qr_btn), "hotspot-pid", pid_copy);
+    g_object_set_data(G_OBJECT(qr_btn), "hotspot-iface", iface_copy);
+    g_object_set_data(G_OBJECT(stop_btn), "hotspot-pid", pid_copy);
+    g_object_set_data_full(G_OBJECT(stop_btn), "hotspot-iface", iface_copy, g_free);
+
+    g_signal_connect(qr_btn, "clicked", G_CALLBACK(on_hotspot_qr_clicked), NULL);
+    g_signal_connect(stop_btn, "clicked", G_CALLBACK(on_hotspot_stop_clicked), NULL);
+    gtk_style_context_add_class(gtk_widget_get_style_context(stop_btn), "stop_button");
+
+    gtk_box_pack_start(GTK_BOX(row_box), info, TRUE, TRUE, 0);
+    gtk_box_pack_end(GTK_BOX(row_box), stop_btn, FALSE, FALSE, 0);
+    gtk_box_pack_end(GTK_BOX(row_box), qr_btn, FALSE, FALSE, 0);
+
+    gtk_widget_show_all(row_box);
+    gtk_list_box_insert(GTK_LIST_BOX(hotspot_listbox), row_box, -1);
+}
+
+static void update_hotspot_list_view_from(RunningHotspot *hotspots, int count) {
+    int i;
+
+    clear_hotspot_list();
+
+    for (i = 0; i < count; i++)
+        add_hotspot_row(&hotspots[i]);
+
+    if (count > 0) {
+        GtkListBoxRow *first = gtk_list_box_get_row_at_index(GTK_LIST_BOX(hotspot_listbox), 0);
+        if (first != NULL)
+            gtk_list_box_select_row(GTK_LIST_BOX(hotspot_listbox), first);
+    }
+}
+
+static void update_hotspot_list_view(void) {
+    RunningHotspot *hotspots = NULL;
+    int count = 0;
+
+    if (get_running_hotspots(&hotspots, &count) == 0 && count > 0)
+        update_hotspot_list_view_from(hotspots, count);
+    else
+        clear_hotspot_list();
+
+    free_running_hotspots(hotspots);
+}
 
 
 static void *stopHp(void *) {
-    if(running_info[0]!=NULL){
-        gtk_label_set_label(label_status,"Stopping ...");
-        start_pb_pulse();
-        lock_all_views(TRUE);
-        startShell(build_kill_create_ap_command(running_info[0]));
-        g_thread_new("init_running",init_running_info,NULL);
-    }
-    return 0;
+    char *stop_id = get_stop_target_id();
+
+    begin_stop_hotspot(stop_id);
+    g_free(stop_id);
+    return NULL;
 }
 
 static void on_create_hp_clicked(GtkWidget *widget, gpointer data) {
 
-
-    init_config_val_input(&configValues);
-
+    if (init_config_val_input(&configValues) != 0) {
+        set_error_text(ERROR_IFACE_MSG);
+        return;
+    }
 
     if(validator(&configValues) == FALSE){
-        set_error_text("Some inputs are not valid!");
+        const char *err = gtk_label_get_text(label_input_error);
+        if (err == NULL || err[0] == '\0')
+            set_error_text("Some inputs are not valid!");
         return;
     }
     else{
         set_error_text("");
     }
 
+    {
+        RunningHotspot *hotspots = NULL;
+        int running_count = 0;
+        int i;
+
+        if (get_running_hotspots(&hotspots, &running_count) == 0) {
+            for (i = 0; i < running_count; i++) {
+                if (strcmp(hotspots[i].phy_iface, configValues.iface_wifi) == 0) {
+                    set_error_text(ERROR_ALREADY_RUNNING_MSG);
+                    free_running_hotspots(hotspots);
+                    return;
+                }
+            }
+        }
+        free_running_hotspots(hotspots);
+    }
+
 
     startShell(build_wh_mkconfig_command(&configValues));
 
+    start_pb_pulse();
+    lock_all_views(TRUE);
     g_thread_new("shell_create_hp", run_create_hp_shell, (void*)build_wh_from_config());
 
 
@@ -174,9 +560,16 @@ static void on_about_open_click(GtkWidget *widget, gpointer data){
 }
 
 static void on_qr_open_click(GtkWidget *widget, gpointer data){
+    const char *hotspot_id = get_stop_target_id();
 
-    char* image_path = generate_qr_image(configValues.ssid,"WPA",configValues.pass);
-    open_qr(widget,data,image_path);
+    if (hotspot_id != NULL) {
+        show_qr_for_hotspot(widget, hotspot_id);
+        g_free((gpointer) hotspot_id);
+        return;
+    }
+
+    (void)data;
+    set_error_text("No active hotspot for QR code");
 }
 
 
@@ -413,6 +806,7 @@ int initUi(int argc, char *argv[]){
     button_about = (GtkButton *) gtk_builder_get_object(builder, "button_about");
     button_qr = (GtkButton *) gtk_builder_get_object(builder, "button_qr");
     button_refresh = (GtkButton *)gtk_builder_get_object(builder, "button_refresh");
+    gtk_widget_hide(GTK_WIDGET(button_qr));
 
     grid_devices = (GtkGrid *)gtk_builder_get_object(builder, "grid_devices");
 
@@ -452,6 +846,8 @@ int initUi(int argc, char *argv[]){
 
     progress_bar = (GtkProgressBar *) gtk_builder_get_object(builder, "progress_bar");
 
+    init_hotspot_list_ui();
+
     loadStyles();
     init_style_contexts();
 
@@ -480,12 +876,13 @@ int initUi(int argc, char *argv[]){
 
     g_signal_connect (entry_gateway, "changed", G_CALLBACK(entry_gateway_warn), NULL);
 
+    g_signal_connect(combo_wifi, "changed", G_CALLBACK(on_combo_wifi_changed), NULL);
+
     g_signal_connect (rb_freq_2, "toggled", G_CALLBACK(update_freq_toggle), NULL);
     g_signal_connect (rb_freq_5, "toggled", G_CALLBACK(update_freq_toggle), NULL);
     g_signal_connect (rb_freq_auto, "toggled", G_CALLBACK(update_freq_toggle), NULL);
 
 
-    start_pb_pulse();
     g_thread_new("init_running",init_running_info,NULL);
 
     init_interface_list();
@@ -514,7 +911,7 @@ void init_ui_from_config(){
         if(values->pass!=NULL)
             gtk_entry_set_text(entry_pass,values->pass);
 
-        if(strcmp(values->pass,"")==0|| values->pass==NULL)
+        if(values->pass==NULL || strcmp(values->pass,"")==0)
             // This line will trigger on_cb_open_toggle callback and disable the entry_pass
             gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(cb_open),TRUE);
 
@@ -609,11 +1006,13 @@ void init_ui_from_config(){
         }
 
         char *macs =read_mac_filter_file(values->accepted_mac_file);
-        if (macs!=NULL && !strlen(macs)<1){
+        if (macs!=NULL && strlen(macs) > 0){
             gtk_text_buffer_set_text(buffer_mac_filter,macs,strlen(macs));
         }
 
     }
+
+    ensure_interface_selection();
 }
 
 void init_interface_list(){
@@ -632,6 +1031,7 @@ void init_interface_list(){
         gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (combo_wifi), wifi_iface_list[i]);
     }
 
+    ensure_interface_selection();
 }
 
 
@@ -640,7 +1040,7 @@ void lock_all_views(gboolean set_lock){
         gtk_editable_set_editable( (GtkEditable*)entry_ssd,FALSE);
         gtk_editable_set_editable( (GtkEditable*)entry_pass,FALSE);
         gtk_widget_set_sensitive ((GtkWidget*)button_create_hp, FALSE);
-        gtk_widget_set_sensitive ((GtkWidget*)button_stop_hp, FALSE);
+        gtk_widget_set_sensitive ((GtkWidget*)button_stop_hp, TRUE);
         gtk_widget_set_sensitive ((GtkWidget*)combo_internet, FALSE);
         gtk_widget_set_sensitive ((GtkWidget*)combo_wifi, FALSE);
         gtk_widget_set_sensitive ((GtkWidget*)tv_mac_filter, FALSE);
@@ -659,41 +1059,32 @@ void lock_all_views(gboolean set_lock){
 
 
 void lock_running_views(gboolean set_lock){
-    if(set_lock){
-        gtk_editable_set_editable( (GtkEditable*)entry_ssd,FALSE);
-        gtk_editable_set_editable( (GtkEditable*)entry_pass,FALSE);
-        gtk_widget_set_sensitive ((GtkWidget*)button_create_hp, FALSE);
+    gtk_editable_set_editable(GTK_EDITABLE(entry_ssd), TRUE);
+    gtk_editable_set_editable(GTK_EDITABLE(entry_pass), TRUE);
+    gtk_widget_set_sensitive(GTK_WIDGET(combo_internet), TRUE);
+    gtk_widget_set_sensitive(GTK_WIDGET(combo_wifi), TRUE);
+    gtk_widget_set_sensitive(GTK_WIDGET(button_stop_hp), set_lock);
 
-        gtk_widget_set_sensitive ((GtkWidget*)button_stop_hp, TRUE);
-        gtk_widget_set_sensitive ((GtkWidget*)button_qr, TRUE);
+    if (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(cb_mac_filter)))
+        gtk_widget_set_sensitive(GTK_WIDGET(tv_mac_filter), TRUE);
+    else
+        gtk_widget_set_sensitive(GTK_WIDGET(tv_mac_filter), FALSE);
 
-        gtk_widget_set_sensitive ((GtkWidget*)combo_internet, FALSE);
-        gtk_widget_set_sensitive ((GtkWidget*)combo_wifi, FALSE);
-
-        gtk_widget_set_sensitive ((GtkWidget*)tv_mac_filter, FALSE);
-    } else{
-        gtk_editable_set_editable( (GtkEditable*)entry_ssd,TRUE);
-        gtk_editable_set_editable( (GtkEditable*)entry_pass,TRUE);
-        gtk_widget_set_sensitive ((GtkWidget*)button_create_hp, TRUE);
-
-        gtk_widget_set_sensitive ((GtkWidget*)button_stop_hp, FALSE);
-        gtk_widget_set_sensitive ((GtkWidget*)button_qr, FALSE);
-
-        gtk_widget_set_sensitive ((GtkWidget*)combo_internet, TRUE);
-        gtk_widget_set_sensitive ((GtkWidget*)combo_wifi, TRUE);
-
-        if (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(cb_mac_filter)))
-            gtk_widget_set_sensitive ((GtkWidget*)tv_mac_filter, TRUE);
-    }
+    update_create_button_state();
 }
 
 static guint start_pb_pulse(){
+    if (pb_pulse_id > 0)
+        g_source_remove(pb_pulse_id);
     gtk_widget_set_visible((GtkWidget*)progress_bar,TRUE);
-    return pb_pulse_id= g_timeout_add (100, update_progress_in_timeout, progress_bar);
+    return pb_pulse_id = g_timeout_add(100, update_progress_in_timeout, progress_bar);
 }
 
 static void stop_pb_pulse(){
-    g_source_remove(pb_pulse_id);
+    if (pb_pulse_id > 0) {
+        g_source_remove(pb_pulse_id);
+        pb_pulse_id = 0;
+    }
     gtk_widget_set_visible((GtkWidget*)progress_bar,FALSE);
 }
 
@@ -710,41 +1101,79 @@ void clear_running_info(){
         running_info[0]=NULL;
 }
 
-void* init_running_info(void *){
+typedef struct {
+    RunningHotspot *hotspots;
+    int count;
+    int fetch_ok;
+} RunningInfoData;
+
+static gboolean idle_set_status_label(gpointer data) {
+    gtk_label_set_label(label_status, (const char *) data);
+    g_free(data);
+    return G_SOURCE_REMOVE;
+}
+
+static gboolean idle_apply_running_info(gpointer data) {
+    RunningInfoData *info = data;
+    char status[BUFSIZE];
 
     clear_running_info();
-    lock_all_views(TRUE);
 
-    gtk_label_set_label(label_status,"Getting running info...");
-
-    get_h_running_info(running_info);
-
-    if(running_info[0]!=NULL){
-
-        char a[BUFSIZE];
-        snprintf(a,BUFSIZE,"Running as PID: %s",running_info[0]);
-        gtk_label_set_label(label_status,a);
-
+    if (info->fetch_ok == 0 && info->count > 0) {
+        update_hotspot_list_view_from(info->hotspots, info->count);
+        running_info[0] = g_strdup(info->hotspots[0].pid);
+        snprintf(status, BUFSIZE, "%d active hotspot(s) — pick a free WiFi interface to create another", info->count);
+        gtk_label_set_label(label_status, status);
         lock_all_views(FALSE);
         lock_running_views(TRUE);
-
-
-    } else{
-
-        gtk_label_set_label(label_status,"Not running");
+        set_connected_devices_label();
+    } else {
+        clear_hotspot_list();
+        gtk_label_set_label(label_status, "Not running");
         lock_all_views(FALSE);
         lock_running_views(FALSE);
+        clear_connecetd_devices_list();
     }
 
+    free_running_hotspots(info->hotspots);
+    g_free(info);
     stop_pb_pulse();
+    return G_SOURCE_REMOVE;
+}
+
+static void *fetch_running_info_thread(void *data) {
+    RunningInfoData *info = data;
+
+    info->fetch_ok = get_running_hotspots(&info->hotspots, &info->count);
+    g_idle_add(idle_apply_running_info, info);
+    return NULL;
+}
+
+static void *detach_pclose_thread(void *data) {
+    pclose((FILE *) data);
+    return NULL;
+}
+
+void* init_running_info(void *){
+    RunningInfoData *info = g_malloc0(sizeof(RunningInfoData));
+
+    gtk_label_set_label(label_status, "Getting running info...");
+    lock_all_views(TRUE);
+    start_pb_pulse();
+
+    g_thread_new("fetch_running", fetch_running_info_thread, info);
     return 0;
+}
+
+static gboolean idle_refresh_running_info(gpointer data) {
+    init_running_info(data);
+    return G_SOURCE_REMOVE;
 }
 
 
 static void *run_create_hp_shell(void *cmd) {
 
     char buf[BUFSIZE];
-    char buf2[BUFSIZE];
     FILE *fp;
 
     if(configValues.freq){
@@ -753,67 +1182,51 @@ static void *run_create_hp_shell(void *cmd) {
 
         if ((fp = popen(cmd, "r")) == NULL) {
             printf("Error opening pipe!\n");
+            g_idle_add(idle_refresh_running_info, NULL);
             return NULL;
         }
     }
     else{
         if ((fp = popen(cmd, "r")) == NULL) {
             printf("Error opening pipe!\n");
+            g_idle_add(idle_refresh_running_info, NULL);
             return NULL;
         }
     }
 
-
-
-    start_pb_pulse();
-
     while (fgets(buf, BUFSIZE, fp) != NULL) {
         buf[strcspn(buf, "\n")] = 0;
-        gtk_label_set_label(label_status,buf);
+        g_idle_add(idle_set_status_label, g_strdup(buf));
 
         if (strstr(buf, AP_ENABLED) != NULL) {
-            init_running_info(NULL);
-            pclose(fp);
-            return 0;
+            g_idle_add(idle_refresh_running_info, NULL);
+            g_thread_new("create_ap_reap", detach_pclose_thread, fp);
+            return NULL;
         }
     }
 
-    if (pclose(fp)) {
-        printf("Command not found or exited with error status\n");
-        init_running_info(NULL);
-        return NULL;
-    }
-
-    init_running_info(NULL);
+    pclose(fp);
+    g_idle_add(idle_refresh_running_info, NULL);
     return 0;
 }
 
 
 static gboolean validator(ConfigValues *cv){
 
+    if(cv->ssid ==NULL || strlen(cv->ssid) < 1)
+    {
+        set_error_text(ERROR_SSID_MSG);
+        return FALSE;
+    }
 
     if(cv->pass !=NULL)
     {
         size_t len = strlen(cv->pass);
 
-        if(len<8){
-            if(len>0)
+        if(len > 0 && len < 8){
+            set_error_text(ERROR_PASS_MSG);
             return FALSE;
         }
-    }
-
-    if(cv->ssid !=NULL)
-    {
-        size_t len = strlen(cv->ssid);
-
-        if(len<1){
-            return FALSE;
-        }
-    }
-
-    if(cv->ssid ==NULL)
-    {
-        return FALSE;
     }
 
     if(gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(cb_mac))==TRUE) {
@@ -828,45 +1241,58 @@ static gboolean validator(ConfigValues *cv){
 
     if(gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(cb_channel))==TRUE){
 
-        if(cv->channel==NULL)
+        if(cv->channel==NULL || cv->channel[0] == '\0') {
+            set_error_text(ERROR_CHANNEL_MSG);
             return FALSE;
+        }
 
         char *end;
         long li;
         char *c=strdup(cv->channel);
         li = strtol(c,&end,10);
 
-        if (end == c) {
-            fprintf(stderr, "%s: not a decimal number\n", c);
-            return FALSE;
-        } else if ('\0' != *end) {
-            fprintf(stderr, "%s: extra characters at end of input: %s\n", c, end);
+        if (end == c || '\0' != *end) {
+            set_error_text(ERROR_CHANNEL_MSG);
+            free(c);
             return FALSE;
         }
-
 
         if(cv->freq==NULL){
-            if(!(li<=196 && li>0))
+            if(!(li<=196 && li>0)) {
+                set_error_text(ERROR_CHANNEL_MSG);
+                free(c);
                 return FALSE;
+            }
         }
         else if(strcmp(cv->freq,"2.4")==0){
-            if(!(li<=11 && li>0))
+            if(!(li<=11 && li>0)) {
+                set_error_text(ERROR_CHANNEL_MSG_2);
+                free(c);
                 return FALSE;
+            }
         } else if(strcmp(cv->freq,"5")==0){
-            if(!(li<=196 && li>0))
+            if(!(li<=196 && li>0)) {
+                set_error_text(ERROR_CHANNEL_MSG_5);
+                free(c);
                 return FALSE;
+            }
         }
+        free(c);
 
     }
 
     if(gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(cb_mac_filter))==TRUE){
-        if (isValidAcceptedMacs(get_accepted_macs())==-1)
+        if (isValidAcceptedMacs(get_accepted_macs())==-1) {
+            set_error_text(ERROR_MAC_MSG);
             return FALSE;
+        }
     }
 
     if(gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(cb_gateway))==TRUE){
-        if (isValidIPaddress(cv->gateway)==-1)
+        if (cv->gateway == NULL || isValidIPaddress(cv->gateway)==-1) {
+            set_error_text(ERROR_GATEWAY_MSG);
             return FALSE;
+        }
     }
 
 
@@ -1037,16 +1463,18 @@ static void set_connected_devices_label()
 }
 
 /**
- * When conncetd devices refresh button clicked
-*/
+ * When connected devices refresh button clicked
+ */
 static void on_refresh_clicked(GtkWidget *widget, gpointer data)
 {
-    if (running_info[0] != NULL)
-    {
+    (void)widget;
+    (void)data;
+
+    if (running_info[0] != NULL && running_info[0][0] != '\0') {
         set_connected_devices_label();
-    }
-    else {
+    } else {
         clear_connecetd_devices_list();
+        gtk_label_set_label(label_status, "No active hotspot — connect devices list is empty");
     }
 }
 


### PR DESCRIPTION
## Summary

This PR improves hotspot creation/stop reliability and the GTK GUI for day-to-day use, especially on Intel iwlwifi adapters and when WiFi is already connected to an existing network.

- **create_ap**: auto-sync AP channel with STA connection; detect gateway subnet conflicts and fall back to an alternate gateway; cleanup orphaned dnsmasq/hostapd processes and stale `ap*` interfaces; stronger `--stop` with forced cleanup; new `--show-info` command; readable config files for non-root GUI access
- **GUI**: active hotspot list with per-row Stop/QR buttons; right-click hotspot details; non-blocking create/stop/refresh; fix progress bar stuck after AP start; fix QR generation path/permissions; allow creating on a free WiFi interface while another hotspot is running; top Stop only stops the selected list row
- **wihotspot launcher**: drop back to the desktop user when started via `sudo`

## Test plan

- [x] Create hotspot as normal user (`wihotspot`) while connected to WiFi on the same adapter (Intel AX201 / iwlwifi)
- [x] Stop hotspot from list row and from top Stop after selecting a row
- [x] Right-click hotspot row shows SSID/password/security details
- [x] Generate QR code from hotspot list row
- [x] Refresh connected devices without resetting hotspot list
- [x] Recover from orphaned `dnsmasq` / stale `ap0` with `create_ap --stop <iface>`
- [ ] Verify on a system with two WiFi adapters that a second hotspot can be created on the unused interface
- [ ] Confirm `make` / CI build on a clean Ubuntu install


Made with [Cursor](https://cursor.com)