### PR TITLE
Fix hotspot creation failing out of the box on brcmfmac adapters, and surface create_ap errors in the GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@
 
 
 ### What's new
+* Errors from `create_ap` are now shown in the GUI instead of failing silently ([#525](https://github.com/lakinduakash/linux-wifi-hotspot/pull/525))
+* WiFi and Internet interfaces are preselected, so hotspot creation works out of the box ([#525](https://github.com/lakinduakash/linux-wifi-hotspot/pull/525))
+* Virtual interfaces are no longer refused on PCIe/USB `brcmfmac` adapters ([#525](https://github.com/lakinduakash/linux-wifi-hotspot/pull/525))
 * Use aa-complain instead of complain to fix the permission issue for dnsmasq
 * Fix some 5Ghz band not working issue
 * Compatible with iw 6.7
@@ -52,6 +55,8 @@ If you only need the command line without GUI run `make install-cli-only` as the
 - If any problems with **RealTeK Wifi Adapters** see [this](docs/howto/realtek.md)
 
 - **Unable to allocate IP: firewalld issue:** Please check for potential fixes: [#209](https://github.com/lakinduakash/linux-wifi-hotspot/issues/209) [#166](https://github.com/lakinduakash/linux-wifi-hotspot/issues/166)
+
+- **Clients see the hotspot but cannot connect:** if devices keep associating and disconnecting, your adapter's firmware may not support AP mode with encryption. `create_ap` now warns when it detects this. Broadcom adapters in T2 Macs are known to be affected, and no `create_ap` option works around it - a USB WiFi adapter is needed. See [#525](https://github.com/lakinduakash/linux-wifi-hotspot/pull/525).
 
 ## Installation
 

--- a/src/scripts/create_ap
+++ b/src/scripts/create_ap
@@ -1681,7 +1681,7 @@ if [[ $NO_VIRT -eq 0 ]]; then
             FREQ_BAND=2.4
         fi
         if [[ $WIFI_IFACE_CHANNEL -ne $CHANNEL ]]; then
-            if ( get_adapter_info ${IFACE} | grep "#channels <= 2" -q )
+            if ( get_adapter_info ${WIFI_IFACE} | grep "#channels <= 2" -q )
             then
                 echo -e "\nmultiple channels supported"
             else

--- a/src/scripts/create_ap
+++ b/src/scripts/create_ap
@@ -299,15 +299,32 @@ get_adapter_kernel_module() {
     echo ${MODULE##*/}
 }
 
+# Bus the adapter is attached to (pci, sdio, usb, ...). Empty if unknown.
+get_adapter_bus() {
+    local SUBSYSTEM
+    SUBSYSTEM=$(readlink -f "/sys/class/net/$1/device/subsystem" 2>/dev/null)
+    echo ${SUBSYSTEM##*/}
+}
+
 can_be_sta_and_ap() {
     # iwconfig does not provide this information, assume false
     [[ $USE_IWCONFIG -eq 1 ]] && return 1
     if [[ "$(get_adapter_kernel_module "$1")" == "brcmfmac" ]]; then
-        echo "WARN: brmfmac driver doesn't work properly with virtual interfaces and" >&2
-        echo "      it can cause kernel panic. For this reason we disallow virtual" >&2
-        echo "      interfaces for your adapter." >&2
-        echo "      For more info: https://github.com/oblique/create_ap/issues/203" >&2
-        return 1
+        # Adding a virtual interface panics the kernel on SDIO-attached
+        # brcmfmac chips, so those stay disallowed unconditionally:
+        # https://github.com/oblique/create_ap/issues/203
+        # That report is specific to SDIO. PCIe and USB parts are not
+        # affected, so for those we trust the interface combinations the
+        # driver advertises, exactly as we do for every other driver.
+        if [[ "$(get_adapter_bus "$1")" == "sdio" ]]; then
+            echo "WARN: brcmfmac driver doesn't work properly with virtual interfaces and" >&2
+            echo "      it can cause kernel panic. For this reason we disallow virtual" >&2
+            echo "      interfaces for your SDIO adapter." >&2
+            echo "      For more info: https://github.com/oblique/create_ap/issues/203" >&2
+            return 1
+        fi
+        echo "WARN: virtual interface support varies between brcmfmac chips. If the" >&2
+        echo "      AP fails to start or the adapter stops working, try --no-virt." >&2
     fi
     get_adapter_info "$1" | grep -E '{.* managed.* AP.*}' > /dev/null 2>&1 && return 0
     get_adapter_info "$1" | grep -E '{.* AP.* managed.*}' > /dev/null 2>&1 && return 0

--- a/src/scripts/create_ap
+++ b/src/scripts/create_ap
@@ -2036,12 +2036,43 @@ if [[ $NO_HAVEGED -eq 0 ]]; then
     HAVEGED_WATCHDOG_PID=$!
 fi
 
+# Pass hostapd's output through unchanged, but watch it for clients that
+# associate and are dropped again without ever completing the WPA handshake.
+# Some adapters beacon happily while their firmware rejects AP-mode key
+# setup, so the AP looks up and every client silently fails to connect.
+handshake_watchdog() {
+    local line assoc=0 checked=0
+
+    while IFS= read -r line; do
+        echo "$line"
+
+        [[ $checked -eq 1 ]] && continue
+
+        case "$line" in
+            *AP-STA-CONNECTED*|*"pairwise key handshake completed"*)
+                # a client got through, nothing to warn about
+                checked=1
+                ;;
+            *"IEEE 802.11: associated"*)
+                assoc=$((assoc + 1))
+                if [[ $assoc -ge 3 ]]; then
+                    checked=1
+                    echo "WARN: clients keep associating and disconnecting without completing the" >&2
+                    echo "      WPA handshake. Your adapter's firmware may not support AP mode with" >&2
+                    echo "      encryption. Check 'dmesg' for driver errors, and try an open network" >&2
+                    echo "      (empty passphrase) to see whether encryption is the problem." >&2
+                fi
+                ;;
+        esac
+    done
+}
+
 # start hostapd (use stdbuf when available for no delayed output in programs that redirect stdout)
 STDBUF_PATH=`which stdbuf`
 if [ $? -eq 0 ]; then
     STDBUF_PATH=$STDBUF_PATH" -oL"
 fi
-$STDBUF_PATH $HOSTAPD $HOSTAPD_DEBUG_ARGS $CONFDIR/hostapd.conf &
+$STDBUF_PATH $HOSTAPD $HOSTAPD_DEBUG_ARGS $CONFDIR/hostapd.conf > >(handshake_watchdog) &
 HOSTAPD_PID=$!
 echo $HOSTAPD_PID > $CONFDIR/hostapd.pid
 

--- a/src/ui/h_prop.c
+++ b/src/ui/h_prop.c
@@ -65,21 +65,76 @@ static const char* g_pass=NULL;
 
 static char* qr_image_path;
 
+static char last_shell_error[BUFSIZE];
+static char last_shell_line[BUFSIZE];
+
 //config_t cfg;
+
+void clear_last_shell_error(void){
+    last_shell_error[0] = '\0';
+    last_shell_line[0] = '\0';
+}
+
+const char* get_last_shell_error(void){
+
+    if(last_shell_error[0] != '\0')
+        return last_shell_error;
+
+    return last_shell_line[0] != '\0' ? last_shell_line : NULL;
+}
+
+void record_shell_error_line(const char *line){
+
+    while (*line == ' ')
+        line++;
+
+    if(*line == '\0')
+        return;
+
+    // Not every failure is tagged: the root check, hostapd and pkexec all
+    // print plain text, so keep the last real line as a fallback
+    if(strncmp(line, "Doing cleanup", 13) != 0 && strcmp(line, "done") != 0)
+        snprintf(last_shell_line, BUFSIZE, "%s", line);
+
+    // The first ERROR: line names the actual cause, later ones are fallout
+    if(last_shell_error[0] != '\0')
+        return;
+
+    if(strncmp(line, "ERROR:", 6) == 0){
+        const char *msg = line + 6;
+        while (*msg == ' ')
+            msg++;
+        snprintf(last_shell_error, BUFSIZE, "%s", msg);
+    }
+    else if(strstr(line, "Not authorized") != NULL || strstr(line, "dismissed") != NULL){
+        snprintf(last_shell_error, BUFSIZE, "Authorization failed or was cancelled");
+    }
+}
 
 static int parse_output(const char *cmd) {
 
     char buf[BUFSIZE];
+    char cmd_line[BUFSIZE + 8];
     FILE *fp;
 
-    if ((fp = popen(cmd, "r")) == NULL) {
+    clear_last_shell_error();
+
+    // create_ap reports every failure on stderr, so fold it into the pipe -
+    // otherwise the caller has no way to tell the user what went wrong.
+    // The braces keep the redirect applied to the whole command.
+    snprintf(cmd_line, sizeof(cmd_line), "{ %s ; } 2>&1", cmd);
+
+    if ((fp = popen(cmd_line, "r")) == NULL) {
         printf("Error opening pipe!\n");
+        snprintf(last_shell_error, BUFSIZE, "Could not run %s", CREATE_AP);
         return -1;
     }
 
     while (fgets(buf, BUFSIZE, fp) != NULL) {
         // Do whatever you want here...
         printf("%s", buf);
+        buf[strcspn(buf, "\n")] = '\0';
+        record_shell_error_line(buf);
     }
 
     if (pclose(fp)) {
@@ -365,6 +420,29 @@ char** get_interface_list(int *length){
 
     return NULL;
 
+}
+
+
+// Interface carrying the default route, i.e. the one that actually has
+// Internet. Returns NULL when there is no default route.
+const char* get_default_route_interface(){
+
+    static char iface[64];
+    FILE *fp;
+
+    iface[0] = '\0';
+
+    if ((fp = popen("ip -o route show default 2>/dev/null | awk '{print $5; exit}'", "r")) == NULL) {
+        printf("Error opening pipe!\n");
+        return NULL;
+    }
+
+    if (fgets(iface, sizeof(iface), fp) != NULL)
+        iface[strcspn(iface, "\n")] = '\0';
+
+    pclose(fp);
+
+    return iface[0] != '\0' ? iface : NULL;
 }
 
 

--- a/src/ui/h_prop.h
+++ b/src/ui/h_prop.h
@@ -67,6 +67,12 @@ const char *build_wh_mkconfig_command(ConfigValues* cv);
 
 char** get_wifi_interface_list(int *length);
 
+const char* get_default_route_interface(void);
+
+void clear_last_shell_error(void);
+const char* get_last_shell_error(void);
+void record_shell_error_line(const char *line);
+
 void write_accepted_macs(char* filename, char* accepted_macs);
 
 char * read_mac_filter_file(char * filename);

--- a/src/ui/ui.c
+++ b/src/ui/ui.c
@@ -43,6 +43,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "qr_ui.h"
 
 #define BUFSIZE 512
+#define CMD_BUFSIZE 2304
 #define AP_ENABLED "AP-ENABLED"
 
 #define INSTALL_PATH_PREFIX "/usr/share/wihotspot"
@@ -53,6 +54,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define ERROR_CHANNEL_MSG_5 "Channel must be 1-196"
 #define ERROR_MAC_MSG "Invalid Mac address"
 #define ERROR_GATEWAY_MSG "Invalid gateway IP address"
+#define ERROR_IFACE_MSG "Please select WiFi and Internet interfaces"
+#define ERROR_START_MSG "Could not start the hotspot. Run wihotspot from a terminal for details."
+#define ERROR_CONFIG_MSG "Could not write the configuration file"
 
 #define DEFAULT_GATEWAY_IP "192.168.12.1"
 
@@ -145,7 +149,10 @@ static void *stopHp(void *) {
 static void on_create_hp_clicked(GtkWidget *widget, gpointer data) {
 
 
-    init_config_val_input(&configValues);
+    if(init_config_val_input(&configValues) != 0){
+        set_error_text(ERROR_IFACE_MSG);
+        return;
+    }
 
 
     if(validator(&configValues) == FALSE){
@@ -157,7 +164,10 @@ static void on_create_hp_clicked(GtkWidget *widget, gpointer data) {
     }
 
 
-    startShell(build_wh_mkconfig_command(&configValues));
+    if(startShell(build_wh_mkconfig_command(&configValues)) != 0){
+        show_shell_error(ERROR_CONFIG_MSG);
+        return;
+    }
 
     g_thread_new("shell_create_hp", run_create_hp_shell, (void*)build_wh_from_config());
 
@@ -201,8 +211,15 @@ static void init_style_contexts(){
 
 }
 
-static void set_error_text(char * text){
+static void set_error_text(const char * text){
     gtk_label_set_label(label_input_error,text);
+}
+
+/* Show whatever create_ap complained about, falling back to a generic hint
+   when it died without a recognisable message. */
+static void show_shell_error(const char *fallback){
+    const char *err = get_last_shell_error();
+    set_error_text(err != NULL ? err : fallback);
 }
 
 static void* entry_mac_warn(GtkWidget *widget, gpointer data){
@@ -490,6 +507,7 @@ int initUi(int argc, char *argv[]){
 
     init_interface_list();
     init_ui_from_config();
+    select_default_interfaces();
 
 
     gtk_main();
@@ -637,6 +655,35 @@ void init_interface_list(){
 }
 
 
+/* The shipped config names wlan0/eth0, which exist on hardly any machine, so
+   neither combo ends up selected and Create silently does nothing. Fall back
+   to the interfaces this machine actually has. */
+void select_default_interfaces(){
+
+    if(gtk_combo_box_get_active(combo_wifi) < 0 && wifi_iface_list_length > 0)
+        gtk_combo_box_set_active(combo_wifi, 0);
+
+    if(gtk_combo_box_get_active(combo_internet) < 0 && iface_list_length > 0){
+
+        const char *route_iface = get_default_route_interface();
+        int id = -1;
+
+        // the interface holding the default route is the one with Internet
+        if(route_iface != NULL)
+            id = find_str((char*)route_iface, iface_list, iface_list_length);
+
+        // no default route: anything but loopback is a better guess than lo
+        for (int i = 0; id == -1 && i < iface_list_length; i++){
+            if(strcmp(iface_list[i], "lo") != 0)
+                id = i;
+        }
+
+        if(id != -1)
+            gtk_combo_box_set_active(combo_internet, id);
+    }
+}
+
+
 void lock_all_views(gboolean set_lock){
     if(set_lock){
         gtk_editable_set_editable( (GtkEditable*)entry_ssd,FALSE);
@@ -746,26 +793,24 @@ void* init_running_info(void *){
 static void *run_create_hp_shell(void *cmd) {
 
     char buf[BUFSIZE];
-    char buf2[BUFSIZE];
+    char cmd_line[CMD_BUFSIZE];
     FILE *fp;
 
-    if(configValues.freq){
-        cmd = strcat( cmd, " --freq-band ");
-        cmd = strcat(cmd, configValues.freq);
+    clear_last_shell_error();
 
-        if ((fp = popen(cmd, "r")) == NULL) {
-            printf("Error opening pipe!\n");
-            return NULL;
-        }
+    /* create_ap reports every failure on stderr, so fold it into the pipe -
+       without it a failed start leaves the user with no reason at all */
+    if(configValues.freq)
+        snprintf(cmd_line, CMD_BUFSIZE, "{ %s --freq-band %s ; } 2>&1", (char*)cmd, configValues.freq);
+    else
+        snprintf(cmd_line, CMD_BUFSIZE, "{ %s ; } 2>&1", (char*)cmd);
+
+    if ((fp = popen(cmd_line, "r")) == NULL) {
+        printf("Error opening pipe!\n");
+        set_error_text(ERROR_START_MSG);
+        init_running_info(NULL);
+        return NULL;
     }
-    else{
-        if ((fp = popen(cmd, "r")) == NULL) {
-            printf("Error opening pipe!\n");
-            return NULL;
-        }
-    }
-
-
 
     int ap_enabled = 0;
 
@@ -775,7 +820,9 @@ static void *run_create_hp_shell(void *cmd) {
        popen() handle and can block the child on a full pipe buffer */
     while (fgets(buf, BUFSIZE, fp) != NULL) {
         buf[strcspn(buf, "\n")] = 0;
+        printf("%s\n", buf);
         gtk_label_set_label(label_status,buf);
+        record_shell_error_line(buf);
 
         if (!ap_enabled && strstr(buf, AP_ENABLED) != NULL) {
             ap_enabled = 1;
@@ -785,6 +832,7 @@ static void *run_create_hp_shell(void *cmd) {
 
     if (pclose(fp)) {
         printf("Command not found or exited with error status\n");
+        show_shell_error(ERROR_START_MSG);
         init_running_info(NULL);
         return NULL;
     }

--- a/src/ui/ui.h
+++ b/src/ui/ui.h
@@ -48,6 +48,8 @@ static void* run_create_hp_shell(void *cmd);
 
 void init_interface_list();
 
+void select_default_interfaces();
+
 void* init_running_info(void *);
 
 static gboolean update_progress_in_timeout (gpointer pbar);
@@ -66,7 +68,9 @@ static int init_config_val_input(ConfigValues* cv);
 
 static gboolean validator(ConfigValues *cv);
 
-static void set_error_text(char * text);
+static void set_error_text(const char * text);
+
+static void show_shell_error(const char *fallback);
 
 gchar* get_accepted_macs();
 


### PR DESCRIPTION
Four fixes for hotspot creation failing out of the box, found while debugging a machine where `wihotspot` started and immediately stopped with nothing shown in the UI.

## `create_ap`

**Only refuse virtual interfaces on SDIO brcmfmac adapters.** `can_be_sta_and_ap()` returned false for *every* `brcmfmac` adapter, citing oblique/create_ap#203. That report is about SDIO-attached chips, where adding a virtual interface could panic the kernel — PCIe and USB parts are not affected, but were blocked all the same. Any associated brcmfmac card failed with `Your adapter can not be a station (i.e. be connected) and an AP at the same time`, even when the driver advertised concurrency.

SDIO keeps the unconditional refusal. Other buses fall through to the interface-combination check every other driver already gets, with a warning that support varies so users know to try `--no-virt`.

Verified on a PCIe BCM4364 advertising `#{ managed } <= 1, #{ AP } <= 2, total <= 4, #channels <= 2` — adding a virtual `__ap` interface while associated causes no panic and the station link survives. The hotspot now reaches `AP-ENABLED` on hardware that previously refused to start at all.

**Use `WIFI_IFACE` in the multi-channel capability check.** `$IFACE` is never set, so `get_adapter_info` got an empty argument, `get_phy_device` failed, and the grep for `#channels <= 2` never matched. Every adapter was treated as unable to use a second channel, pinning the AP to the station's channel even on cards supporting two.

**Warn when clients never complete the WPA handshake.** Some adapters beacon fine while their firmware rejects AP-mode key setup: hostapd reports `AP-ENABLED`, the SSID is visible, clients associate — and the 4-way handshake never completes, so each one is dropped a second later. The output is an endless `associated` / `disassociated` loop with no explanation, which reads like a create_ap bug.

hostapd's stdout now passes through a filter that forwards every line unchanged but counts associations. After three with no `AP-STA-CONNECTED` and no completed handshake it prints a warning pointing at the driver and suggesting an open network to isolate encryption as the cause. Process substitution keeps hostapd as the direct child, so `HOSTAPD_PID`, the pidfile, `wait` and `cleanup` are unaffected.

## GUI

**Show `create_ap` errors instead of failing silently.** Both `popen()` call sites captured only stdout, but `create_ap` reports every failure on stderr. A failed start produced no visible reason at all — the status label went straight back to "Not running", and the message was only seen by users who had launched `wihotspot` from a terminal.

stderr is now folded into the pipe and the failure remembered: the first `ERROR:` line wins, untagged failures like the root check keep the last real output line, a cancelled polkit prompt is reported as such, and anything else falls back to a generic hint. The `--mkconfig` step is checked too, rather than starting the hotspot with a config that was never written.

**Preselect usable interfaces.** The shipped config names `wlan0`/`eth0`, which exist on hardly any machine, so `find_str()` matched nothing, neither combo ended up selected, and Create silently did nothing while `init_config_val_input()` logged to a terminal nobody was reading. Now defaults to the first WiFi device and the interface holding the default route, and the "no interface selected" case is reported in the UI.

## Testing

- Virtual-interface probe on PCIe brcmfmac: no panic, station link and internet survive, clean teardown.
- Full `--mkconfig` then `--config` run as the GUI performs it: reaches `AP-ENABLED`, no leftover `ap0`, NAT rules or temp dirs.
- Error surfacing exercised against the compiled objects across five failure modes (not-root, cancelled polkit, tagged `ERROR:`, pipe failure, success).
- Handshake watchdog unit-tested on three synthetic hostapd logs: fails-to-connect warns once; successful connect followed by later reassociations stays quiet; two attempts stay quiet.
- Interface defaults verified against the real `get_interface_list` / `get_wifi_interface_list` / default route.
- `make` clean with no new warnings, `./build/test` passes, GUI launches.

## Not addressed here

- `make install` overwrites `/etc/create_ap.conf` (`install -CDm644`), wiping saved settings on every upgrade. Fixing it means deciding how config migration interacts with the debian `conffiles` handling.
- `haveged_watchdog()` warns when `entropy_avail < 1000`, but that file has been capped at 256 since kernel 5.18, so every user on a modern kernel sees `WARN: Low entropy detected` on every run.
- `get_wifi_interface_list()` parses `iw dev`, so a leftover `ap0` from a crashed run appears as a selectable "WiFi interface".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
