### PR TITLE
Port backend and QR fixes from #519 (hotspot state recovery, gateway conflicts, --show-info)

### DIFF
--- a/src/scripts/create_ap
+++ b/src/scripts/create_ap
@@ -566,6 +566,47 @@ cleanup_orphaned_create_ap_for_iface() {
     done
 }
 
+gateway_subnet_conflicts() {
+    local gw=$1
+    local gw_prefix="${gw%.*}"
+    local cidr ip
+
+    if ip route show default 2>/dev/null | grep -Eq "[[:space:]]via ${gw}[[:space:]]"; then
+        return 0
+    fi
+
+    while read -r cidr; do
+        ip="${cidr%%/*}"
+        [[ "${ip%.*}" == "$gw_prefix" ]] && return 0
+    done < <(ip -4 -o addr show scope global | awk '{print $4}')
+
+    return 1
+}
+
+pick_alternate_gateway() {
+    local candidate
+
+    for candidate in 192.168.43.1 10.42.0.1 192.168.4.1 172.16.42.1; do
+        if ! gateway_subnet_conflicts "$candidate"; then
+            echo "$candidate"
+            return 0
+        fi
+    done
+
+    echo "10.42.0.1"
+}
+
+adjust_gateway_for_conflicts() {
+    local new_gw
+
+    if gateway_subnet_conflicts "$GATEWAY"; then
+        new_gw=$(pick_alternate_gateway)
+        echo "WARN: Gateway ${GATEWAY} conflicts with an existing network connection." >&2
+        echo "WARN: Using alternate gateway ${new_gw} instead." >&2
+        GATEWAY=$new_gw
+    fi
+}
+
 # start haveged when needed
 haveged_watchdog() {
     local show_warn=1
@@ -1598,8 +1639,10 @@ if [[ $CHANNEL == default ]]; then
     USING_DEFAULT_CHANNEL=1
     if [[ $FREQ_BAND == 2.4 ]]; then
         CHANNEL=1
-    else
+    elif [[ $FREQ_BAND == 5 ]]; then
         CHANNEL=36
+    else
+        CHANNEL=1
     fi
 else
     USING_DEFAULT_CHANNEL=0
@@ -1903,7 +1946,7 @@ fi
 if can_transmit_to_channel "${WIFI_IFACE}" "${CHANNEL}"; then
     echo "Transmitting to channel ${CHANNEL}..."
 else
-    if [[ $USING_DEFAULT_CHANNEL -eq 1 && $WIFI_IFACE_CHANNEL -ne $CHANNEL ]]; then
+    if [[ $USING_DEFAULT_CHANNEL -eq 1 && -n "$WIFI_IFACE_CHANNEL" && $WIFI_IFACE_CHANNEL -ne $CHANNEL ]]; then
         echo -e "Your adapter can not transmit to channel ${CHANNEL}" >&2
         CHANNEL=$WIFI_IFACE_CHANNEL
         echo -e "Falling back to channel ${CHANNEL}"
@@ -2020,6 +2063,10 @@ EOF
     fi
 fi
 
+
+if [[ "$SHARE_METHOD" != "bridge" ]]; then
+    adjust_gateway_for_conflicts
+fi
 
 if [[ "$SHARE_METHOD" == "bridge" ]]; then
     echo "bridge=${BRIDGE_IFACE}" >> $CONFDIR/hostapd.conf

--- a/src/scripts/create_ap
+++ b/src/scripts/create_ap
@@ -75,6 +75,7 @@ usage() {
     echo "  --stop <id>             Send stop command to an already running create_ap. For an <id>"
     echo "                          you can put the PID of create_ap or the WiFi interface. You can"
     echo "                          get them with --list-running"
+    echo "  --show-info <id>        Show SSID, security and other details for a running hotspot"
     echo "  --list-running          Show the create_ap processes that are already running"
     echo "  --list-clients <id>     List the clients connected to create_ap instance associated with <id>."
     echo "                          For an <id> you can put the PID of create_ap or the WiFi interface."
@@ -551,7 +552,7 @@ cleanup_orphaned_create_ap_confdir() {
 
     echo "Cleaning orphaned hotspot data from $confdir..."
     for y in "$confdir"/*.pid; do
-        [[ -f "$y" ]] && kill -9 $(cat "$y") 2>/dev/null
+        [[ -f "$y" ]] && kill -9 "$(cat "$y")" 2>/dev/null
     done
     pkill -f "dnsmasq -C ${confdir}/dnsmasq.conf" 2>/dev/null || true
     rm -rf "$confdir"
@@ -855,6 +856,7 @@ CONFIG_OPTS=(CHANNEL GATEWAY WPA_VERSION ETC_HOSTS DHCP_DNS NO_DNS NO_DNSMASQ HI
 FIX_UNMANAGED=0
 LIST_RUNNING=0
 STOP_ID=
+SHOW_INFO_ID=
 LIST_CLIENTS_ID=
 
 STORE_CONFIG=
@@ -1229,6 +1231,110 @@ send_stop() {
     fi
 }
 
+find_running_confdir_for_id() {
+    local id=$1
+    local x pid iface
+
+    if [[ "$id" =~ ^[1-9][0-9]*$ ]]; then
+        for x in /tmp/create_ap.*; do
+            [[ -d "$x" && -f "$x/pid" ]] || continue
+            pid=$(cat "$x/pid" 2>/dev/null)
+            [[ "$pid" == "$id" && -d "/proc/$pid" ]] || continue
+            echo "$x"
+            return 0
+        done
+        return 1
+    fi
+
+    iface=$id
+    for x in /tmp/create_ap.${iface}.conf.*; do
+        [[ -d "$x" && -f "$x/pid" ]] || continue
+        pid=$(cat "$x/pid" 2>/dev/null)
+        [[ -n "$pid" && -d "/proc/$pid" ]] || continue
+        echo "$x"
+        return 0
+    done
+
+    return 1
+}
+
+show_hotspot_info() {
+    local id=$1
+    local confdir pid phy_iface ap_iface internet_iface="none"
+    local ssid="" channel="" hw_mode="" hidden="0"
+    local wpa="" key_mgmt="" passphrase="" psk="" gateway="" encryption="" band=""
+
+    confdir=$(find_running_confdir_for_id "$id") || die "No running hotspot found for $id"
+
+    [[ -f "$confdir/pid" ]] && pid=$(cat "$confdir/pid")
+    [[ -f "$confdir/wifi_iface" ]] && ap_iface=$(cat "$confdir/wifi_iface")
+    [[ -f "$confdir/nat_internet_iface" ]] && internet_iface=$(cat "$confdir/nat_internet_iface")
+
+    phy_iface=${confdir#/tmp/create_ap.}
+    phy_iface=${phy_iface%%.conf.*}
+
+    if [[ -f "$confdir/hostapd.conf" ]]; then
+        while IFS= read -r line; do
+            case "$line" in
+                ssid=*) ssid="${line#ssid=}" ;;
+                channel=*) channel="${line#channel=}" ;;
+                hw_mode=*) hw_mode="${line#hw_mode=}" ;;
+                ignore_broadcast_ssid=*) hidden="${line#ignore_broadcast_ssid=}" ;;
+                wpa=*) wpa="${line#wpa=}" ;;
+                wpa_key_mgmt=*) key_mgmt="${line#wpa_key_mgmt=}" ;;
+                wpa_passphrase=*) passphrase="${line#wpa_passphrase=}" ;;
+                wpa_psk=*) psk="${line#wpa_psk=}" ;;
+            esac
+        done < "$confdir/hostapd.conf"
+    fi
+
+    if [[ -f "$confdir/dnsmasq.conf" ]]; then
+        gateway=$(grep -m1 '^listen-address=' "$confdir/dnsmasq.conf" | cut -d= -f2-)
+    fi
+
+    if [[ -z "$passphrase" && -n "$psk" ]]; then
+        passphrase=$psk
+    fi
+
+    if [[ -z "$passphrase" && -z "$psk" ]]; then
+        encryption="Open"
+    elif [[ "$key_mgmt" == *SAE* ]]; then
+        encryption="WPA2/WPA3"
+    elif [[ "$wpa" == "3" ]]; then
+        encryption="WPA3"
+    elif [[ "$wpa" == "2" ]]; then
+        encryption="WPA2-PSK"
+    elif [[ "$wpa" == "1" ]]; then
+        encryption="WPA-PSK"
+    elif [[ -n "$psk" ]]; then
+        encryption="WPA-PSK (hex)"
+    else
+        encryption="WPA-PSK"
+    fi
+
+    if [[ "$hw_mode" == "a" ]]; then
+        band="5 GHz"
+    elif [[ "$hw_mode" == "g" ]]; then
+        band="2.4 GHz"
+    fi
+
+    echo "PID=${pid:-}"
+    echo "PHY_IFACE=${phy_iface:-}"
+    echo "AP_IFACE=${ap_iface:-}"
+    echo "INTERNET_IFACE=${internet_iface:-none}"
+    echo "SSID=${ssid:-}"
+    echo "PASSPHRASE=${passphrase:-}"
+    echo "ENCRYPTION=${encryption:-}"
+    echo "GATEWAY=${gateway:-}"
+    echo "CHANNEL=${channel:-}"
+    echo "BAND=${band:-}"
+    if [[ "$hidden" == "1" ]]; then
+        echo "HIDDEN=Yes"
+    else
+        echo "HIDDEN=No"
+    fi
+}
+
 # Storing configs
 write_config() {
     local i=1
@@ -1330,7 +1436,7 @@ for ((i=0; i<$#; i++)); do
     fi
 done
 
-GETOPT_ARGS=$(getopt -o hc:w:g:de:nm: -l "help","hidden","hostapd-debug:","hostapd-timestamps","redirect-to-localhost","mac-filter","mac-filter-accept:","isolate-clients","ieee80211n","ieee80211ac","ieee80211ax","ht_capab:","vht_capab:","driver:","no-virt","fix-unmanaged","country:","freq-band:","mac:","dhcp-dns:","daemon","pidfile:","logfile:","dns-logfile:","stop:","list","list-running","list-clients:","version","psk","no-haveged","no-dns","no-dnsmasq","mkconfig:","config:","dhcp-hosts:" -n "$PROGNAME" -- "$@")
+GETOPT_ARGS=$(getopt -o hc:w:g:de:nm: -l "help","hidden","hostapd-debug:","hostapd-timestamps","redirect-to-localhost","mac-filter","mac-filter-accept:","isolate-clients","ieee80211n","ieee80211ac","ieee80211ax","ht_capab:","vht_capab:","driver:","no-virt","fix-unmanaged","country:","freq-band:","mac:","dhcp-dns:","daemon","pidfile:","logfile:","dns-logfile:","stop:","show-info:","list","list-running","list-clients:","version","psk","no-haveged","no-dns","no-dnsmasq","mkconfig:","config:","dhcp-hosts:" -n "$PROGNAME" -- "$@")
 [[ $? -ne 0 ]] && exit 1
 eval set -- "$GETOPT_ARGS"
 
@@ -1480,6 +1586,11 @@ while :; do
             STOP_ID="$1"
             shift
             ;;
+        --show-info)
+            shift
+            SHOW_INFO_ID="$1"
+            shift
+            ;;
         --list)
             shift
             LIST_RUNNING=1
@@ -1561,7 +1672,7 @@ if [[ -n "$LOAD_CONFIG" && $# -eq 0 ]]; then
 fi
 
 # Check if required number of positional args are present
-if [[ $# -lt 1 && $FIX_UNMANAGED -eq 0  && -z "$STOP_ID" &&
+if [[ $# -lt 1 && $FIX_UNMANAGED -eq 0  && -z "$STOP_ID" && -z "$SHOW_INFO_ID" &&
       $LIST_RUNNING -eq 0 && -z "$LIST_CLIENTS_ID" ]]; then
     usage >&2
     exit 1
@@ -1606,6 +1717,11 @@ fi
 if [[ -n "$STOP_ID" ]]; then
     echo "Trying to kill $PROGNAME instance associated with $STOP_ID..."
     send_stop "$STOP_ID"
+    exit 0
+fi
+
+if [[ -n "$SHOW_INFO_ID" ]]; then
+    show_hotspot_info "$SHOW_INFO_ID"
     exit 0
 fi
 

--- a/src/scripts/create_ap
+++ b/src/scripts/create_ap
@@ -461,6 +461,111 @@ get_new_macaddr() {
     echo $NEWMAC
 }
 
+get_running_pid_for_wifi_iface() {
+    local wifi_iface=$1
+    local pid iface rest
+
+    while read -r pid iface rest; do
+        [[ -z "$pid" ]] && continue
+        [[ "$iface" == "$wifi_iface" ]] && echo "$pid" && return 0
+    done < <(list_running)
+
+    return 1
+}
+
+remove_ap_interfaces_on_phy() {
+    local wifi_iface=$1
+    local target_phy iface iface_phy iface_type pid
+
+    [[ $USE_IWCONFIG -eq 1 ]] && return 0
+    target_phy=$(get_phy_device "$wifi_iface") || return 0
+
+    while read -r iface; do
+        [[ -z "$iface" ]] && continue
+        is_wifi_interface "$iface" || continue
+        iface_type=$(iw dev "$iface" info 2>/dev/null | awk '/type/ {print $2; exit}')
+        [[ "$iface_type" == "AP" ]] || continue
+        iface_phy=$(get_phy_device "$iface" 2>/dev/null) || continue
+        [[ "$iface_phy" == "$target_phy" ]] || continue
+
+        pid=$(get_pid_from_wifi_iface "$iface")
+        [[ -z "$pid" ]] && pid=$(get_running_pid_for_wifi_iface "$wifi_iface" || true)
+        if [[ -n "$pid" ]] && is_running_pid "$pid"; then
+            continue
+        fi
+
+        echo "Removing AP interface $iface..."
+        ip link set dev "$iface" down 2>/dev/null
+        iw dev "$iface" del 2>/dev/null
+        dealloc_iface "$iface" 2>/dev/null
+    done < <(iw dev | awk '/Interface/ {print $2}')
+}
+
+cleanup_stale_ap_interfaces() {
+    local wifi_iface=$1
+    local target_phy iface iface_phy iface_type pid
+
+    [[ $USE_IWCONFIG -eq 1 ]] && return 0
+    target_phy=$(get_phy_device "$wifi_iface") || return 0
+
+    while read -r iface; do
+        [[ -z "$iface" ]] && continue
+        is_wifi_interface "$iface" || continue
+        iface_type=$(iw dev "$iface" info 2>/dev/null | awk '/type/ {print $2; exit}')
+        [[ "$iface_type" == "AP" ]] || continue
+        iface_phy=$(get_phy_device "$iface" 2>/dev/null) || continue
+        [[ "$iface_phy" == "$target_phy" ]] || continue
+
+        pid=$(get_pid_from_wifi_iface "$iface")
+        if [[ -n "$pid" ]] && is_running_pid "$pid"; then
+            die "Hotspot already running on $iface (PID $pid). Stop it first: create_ap --stop $wifi_iface"
+        fi
+
+        echo "Removing stale AP interface $iface..."
+        ip link set dev "$iface" down 2>/dev/null
+        iw dev "$iface" del 2>/dev/null
+        dealloc_iface "$iface" 2>/dev/null
+    done < <(iw dev | awk '/Interface/ {print $2}')
+}
+
+find_create_ap_confdirs_for_iface() {
+    local wifi_iface=$1
+    local x
+
+    for x in /tmp/create_ap.${wifi_iface}.conf.*; do
+        [[ -d "$x" ]] && echo "$x"
+    done
+}
+
+cleanup_orphaned_create_ap_confdir() {
+    local confdir=$1
+    local pid y
+
+    [[ -d "$confdir" ]] || return 0
+    if [[ -f "$confdir/pid" ]]; then
+        pid=$(cat "$confdir/pid" 2>/dev/null)
+        if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+            return 0
+        fi
+    fi
+
+    echo "Cleaning orphaned hotspot data from $confdir..."
+    for y in "$confdir"/*.pid; do
+        [[ -f "$y" ]] && kill -9 $(cat "$y") 2>/dev/null
+    done
+    pkill -f "dnsmasq -C ${confdir}/dnsmasq.conf" 2>/dev/null || true
+    rm -rf "$confdir"
+}
+
+cleanup_orphaned_create_ap_for_iface() {
+    local wifi_iface=$1
+    local x
+
+    for x in $(find_create_ap_confdirs_for_iface "$wifi_iface"); do
+        cleanup_orphaned_create_ap_confdir "$x"
+    done
+}
+
 # start haveged when needed
 haveged_watchdog() {
     local show_warn=1
@@ -727,6 +832,11 @@ HAVEGED_WATCHDOG_PID=
 
 _cleanup() {
     local PID x
+    local ap_iface saved_wifi_iface
+
+    [[ -f "$CONFDIR/wifi_iface" ]] && ap_iface=$(cat "$CONFDIR/wifi_iface")
+    saved_wifi_iface=$PHYS_WIFI_IFACE
+    [[ -z "$saved_wifi_iface" ]] && saved_wifi_iface=$WIFI_IFACE
 
     trap "" SIGINT SIGUSR1 SIGUSR2 EXIT
     mutex_lock
@@ -839,13 +949,15 @@ _cleanup() {
     fi
 
     if [[ $NO_VIRT -eq 0 ]]; then
-        if [[ -n "$VWIFI_IFACE" ]]; then
-            ip link set down dev ${VWIFI_IFACE}
-            ip addr flush ${VWIFI_IFACE}
+        [[ -z "$VWIFI_IFACE" && -n "$ap_iface" ]] && VWIFI_IFACE=$ap_iface
+        if [[ -n "$VWIFI_IFACE" ]] && is_interface "$VWIFI_IFACE"; then
+            ip link set down dev ${VWIFI_IFACE} 2>/dev/null
+            ip addr flush ${VWIFI_IFACE} 2>/dev/null
             networkmanager_rm_unmanaged_if_needed ${VWIFI_IFACE} ${OLD_MACADDR}
-            iw dev ${VWIFI_IFACE} del
+            iw dev ${VWIFI_IFACE} del 2>/dev/null
             dealloc_iface $VWIFI_IFACE
         fi
+        [[ -n "$saved_wifi_iface" ]] && remove_ap_interfaces_on_phy "$saved_wifi_iface"
     else
         ip link set down dev ${WIFI_IFACE}
         ip addr flush ${WIFI_IFACE}
@@ -1001,7 +1113,7 @@ has_running_instance() {
             fi
         fi
     done
-    mutex_lock
+    mutex_unlock
 
     return 1
 }
@@ -1011,21 +1123,69 @@ is_running_pid() {
 }
 
 send_stop() {
-    local x
+    local id=$1
+    local x y pid wifi_iface confdir
+    local stopped=0
 
-    mutex_lock
-    # send stop signal to specific pid
-    if is_running_pid $1; then
-        kill -USR1 $1
-        mutex_unlock
-        return
+    if [[ "$id" =~ ^[1-9][0-9]*$ ]] && is_running_pid "$id"; then
+        pid=$id
+        wifi_iface=$(get_wifi_iface_from_pid "$pid" 2>/dev/null)
+    else
+        wifi_iface=$id
+        pid=$(get_running_pid_for_wifi_iface "$wifi_iface" || true)
+        [[ -z "$pid" ]] && pid=$(get_pid_from_wifi_iface "$wifi_iface" 2>/dev/null)
     fi
 
-    # send stop signal to specific interface
-    for x in $(list_running | grep -E " \(?${1}( |\)?\$)" | cut -f1 -d' '); do
-        kill -USR1 $x
-    done
-    mutex_unlock
+    if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+        kill -USR1 "$pid" 2>/dev/null
+        for x in $(seq 1 15); do
+            kill -0 "$pid" 2>/dev/null || break
+            sleep 0.2
+        done
+        if kill -0 "$pid" 2>/dev/null; then
+            echo "Force stopping create_ap (PID $pid)..."
+            kill -9 "$pid" 2>/dev/null
+            sleep 0.3
+        fi
+        stopped=1
+    fi
+
+    if [[ -n "$pid" ]]; then
+        confdir=$(get_confdir_from_pid "$pid" 2>/dev/null)
+        if [[ -z "$confdir" ]]; then
+            for x in $(find_create_ap_confdirs_for_iface "$wifi_iface"); do
+                if [[ -f "$x/pid" && $(cat "$x/pid" 2>/dev/null) == "$pid" ]]; then
+                    confdir=$x
+                    break
+                fi
+            done
+        fi
+        if [[ -n "$confdir" && -d "$confdir" ]]; then
+            for y in "$confdir"/*.pid; do
+                [[ -f "$y" ]] && kill -9 "$(cat "$y")" 2>/dev/null
+            done
+            rm -rf "$confdir"
+            stopped=1
+        fi
+    fi
+
+    if [[ -n "$wifi_iface" ]]; then
+        cleanup_orphaned_create_ap_for_iface "$wifi_iface"
+    elif [[ -n "$id" ]]; then
+        cleanup_orphaned_create_ap_for_iface "$id"
+        [[ -z "$wifi_iface" ]] && wifi_iface=$id
+    fi
+
+    [[ -n "$wifi_iface" ]] && remove_ap_interfaces_on_phy "$wifi_iface"
+    [[ -z "$wifi_iface" && -n "$id" ]] && remove_ap_interfaces_on_phy "$id"
+
+    if [[ $stopped -eq 1 ]]; then
+        echo "Hotspot stopped on ${wifi_iface:-$id}."
+    elif [[ -n "$wifi_iface" || -n "$id" ]]; then
+        echo "Forced cleanup completed for ${wifi_iface:-$id}."
+    else
+        echo "No running hotspot found for $id." >&2
+    fi
 }
 
 # Storing configs
@@ -1452,6 +1612,7 @@ if [[ $FREQ_BAND != 5 && $CHANNEL -gt 14 ]]; then
 fi
 
 WIFI_IFACE=$1
+PHYS_WIFI_IFACE=$WIFI_IFACE
 
 if ! is_wifi_interface ${WIFI_IFACE}; then
     echo "ERROR: '${WIFI_IFACE}' is not a WiFi interface" >&2
@@ -1619,6 +1780,15 @@ if [[ $NO_VIRT -eq 1 && "$WIFI_IFACE" == "$INTERNET_IFACE" ]]; then
     exit 1
 fi
 
+cleanup_orphaned_create_ap_for_iface ${WIFI_IFACE}
+
+existing_pid=$(get_running_pid_for_wifi_iface ${WIFI_IFACE} || true)
+if [[ -n "$existing_pid" ]]; then
+    echo "ERROR: Hotspot already running on ${WIFI_IFACE} (PID ${existing_pid})." >&2
+    echo "Stop it first: create_ap --stop ${WIFI_IFACE}" >&2
+    exit 1
+fi
+
 mutex_lock
 trap "cleanup" EXIT
 CONFDIR=$(mktemp -d /tmp/create_ap.${WIFI_IFACE}.conf.XXXXXXXX)
@@ -1658,6 +1828,7 @@ if [[ $USE_IWCONFIG -eq 0 ]]; then
 fi
 
 if [[ $NO_VIRT -eq 0 ]]; then
+    cleanup_stale_ap_interfaces ${WIFI_IFACE}
     VWIFI_IFACE=$(alloc_new_iface ap)
 
     # in NetworkManager 0.9.9 and above we can set the interface as unmanaged without
@@ -1697,8 +1868,9 @@ if [[ $NO_VIRT -eq 0 ]]; then
     fi
 
 
-    VIRTDIEMSG="Maybe your WiFi adapter does not fully support virtual interfaces.
-       Try again with --no-virt."
+    VIRTDIEMSG="Maybe your WiFi adapter does not fully support virtual interfaces,
+       or another AP interface is already active on this adapter.
+       Stop any running hotspot first, or try again with --no-virt."
     echo -n "Creating a virtual WiFi interface... "
 
     if iw dev ${WIFI_IFACE} interface add ${VWIFI_IFACE} type __ap; then

--- a/src/scripts/wihotspot
+++ b/src/scripts/wihotspot
@@ -1,4 +1,13 @@
 #!/bin/sh
 
-# Start wihotspot-gui
-/usr/bin/wihotspot-gui
+# GUI apps should run as the desktop user; only create_ap needs root (via pkexec).
+if [ "$(id -u)" -eq 0 ] && [ -n "${SUDO_USER:-}" ] && [ "$SUDO_USER" != "root" ]; then
+    SUDO_HOME=$(getent passwd "$SUDO_USER" | cut -d: -f6)
+    exec sudo -u "$SUDO_USER" env \
+        DISPLAY="${DISPLAY:-:0}" \
+        XAUTHORITY="${XAUTHORITY:-$SUDO_HOME/.Xauthority}" \
+        DBUS_SESSION_BUS_ADDRESS="${DBUS_SESSION_BUS_ADDRESS:-unix:path=/run/user/$(id -u "$SUDO_USER")/bus}" \
+        /usr/bin/wihotspot-gui "$@"
+fi
+
+exec /usr/bin/wihotspot-gui "$@"

--- a/src/ui/h_prop.c
+++ b/src/ui/h_prop.c
@@ -31,6 +31,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <unistd.h>
 //#include <libconfig.h>
 
 #include "h_prop.h"
@@ -63,7 +64,20 @@ static char accepted_macs[BUFSIZE];
 static const char* g_ssid=NULL;
 static const char* g_pass=NULL;
 
-static char* qr_image_path;
+static char qr_image_path[128];
+
+static char create_ap_invocation[64];
+
+// The GUI normally runs unprivileged and elevates per command, but it can be
+// started as root, in which case pkexec is unnecessary and often unavailable.
+static const char *get_create_ap_invocation(void) {
+    if (geteuid() == 0)
+        snprintf(create_ap_invocation, sizeof(create_ap_invocation), "%s", CREATE_AP);
+    else
+        snprintf(create_ap_invocation, sizeof(create_ap_invocation), "%s %s", SUDO, CREATE_AP);
+
+    return create_ap_invocation;
+}
 
 static char last_shell_error[BUFSIZE];
 static char last_shell_line[BUFSIZE];
@@ -148,7 +162,8 @@ static int parse_output(const char *cmd) {
 
 const char *build_wh_start_command(char *iface_src, char *iface_dest, char *ssid, char *pass) {
 
-    snprintf(cmd_start, BUFSIZE, "%s %s %s %s %s %s", SUDO, CREATE_AP, iface_src, iface_dest, ssid, pass);
+    snprintf(cmd_start, BUFSIZE, "%s %s %s %s %s", get_create_ap_invocation(),
+             iface_src, iface_dest, ssid, pass);
 
     return cmd_start;
 }
@@ -158,7 +173,9 @@ const char *build_wh_mkconfig_command(ConfigValues* cv){
 
     const char* config_ffile_name=get_config_file(CONFIG_FILE_NAME);
 
-    snprintf(cmd_mkconfig, BUFSIZE, "%s %s %s %s '%s' '%s' %s %s",SUDO, CREATE_AP, cv->iface_wifi, cv->iface_inet, cv->ssid, cv->pass,MKCONFIG,config_ffile_name);
+    snprintf(cmd_mkconfig, BUFSIZE, "%s %s %s '%s' '%s' %s %s",
+             get_create_ap_invocation(), cv->iface_wifi, cv->iface_inet,
+             cv->ssid, cv->pass, MKCONFIG, config_ffile_name);
 
     if(cv->freq!=NULL){
         strcat(cmd_mkconfig," --freq-band ");
@@ -218,7 +235,8 @@ const char *build_wh_mkconfig_command(ConfigValues* cv){
 
 const char *build_wh_from_config(){
 
-    snprintf(cmd_config, BUFSIZE, "%s %s %s %s", SUDO, CREATE_AP,LOAD_CONFIG,get_config_file(CONFIG_FILE_NAME));
+    snprintf(cmd_config, BUFSIZE, "%s %s %s", get_create_ap_invocation(),
+             LOAD_CONFIG, get_config_file(CONFIG_FILE_NAME));
     return cmd_config;
 
 }
@@ -229,7 +247,7 @@ int startShell(const char *cmd) {
 
 
 const char* build_kill_create_ap_command(char* pid){
-    snprintf(cmd_kill, BUFSIZE, "%s %s %s %s", SUDO, CREATE_AP,STOP,pid);
+    snprintf(cmd_kill, BUFSIZE, "%s %s %s", get_create_ap_invocation(), STOP, pid);
     return cmd_kill;
 }
 
@@ -237,7 +255,10 @@ void write_accepted_macs(char* filename, char* accepted_macs){
 
     printf("mac filter file %s \n",filename);
 
-    snprintf(cmd_write_mac,BUFSIZE,"%s '%s' %s %s","echo", accepted_macs, "| pkexec -u root tee", filename);
+    if (geteuid() == 0)
+        snprintf(cmd_write_mac, BUFSIZE, "echo '%s' | tee %s", accepted_macs, filename);
+    else
+        snprintf(cmd_write_mac, BUFSIZE, "%s '%s' %s %s", "echo", accepted_macs, "| pkexec -u root tee", filename);
     int r=system(cmd_write_mac);
 
 }
@@ -298,7 +319,7 @@ char * read_mac_filter_file(char * filename){
 static int init_get_running(){
 
     char cmd[BUFSIZE];
-    snprintf(cmd, BUFSIZE, "%s %s --list-running",SUDO, CREATE_AP);
+    snprintf(cmd, BUFSIZE, "%s --list-running", get_create_ap_invocation());
 
     FILE *fp;
 
@@ -517,34 +538,26 @@ char** get_wifi_interface_list(int *length){
 char* generate_qr_image(char* ssid,char* type,char *password){
     char cmd[BUFSIZE];
 
-    qr_image_path = "/tmp/wihotspot_qr.png";
+    const char *ssid_safe = ssid ? ssid : "";
+    const char *type_safe = type ? type : "WPA";
+    const char *pass_safe = password ? password : "";
 
-    // snprintf(cmd, BUFSIZE, "%s -s 10 -d 256 -o %s 'WIFI:S:%s;T:%s;P:%s;;' ","qrencode",qr_image_path, ssid,type,password);
+    // one file per user, so two accounts on the same machine can't collide
+    snprintf(qr_image_path, sizeof(qr_image_path), "/tmp/wihotspot_qr_%d.png", getuid());
+    unlink(qr_image_path);
 
-    // FILE *fp;
+    if (ssid_safe[0] == '\0')
+        return NULL;
 
-    // char temp_buff[1048];
+    // an open network must be advertised as nopass, without a P: field
+    if (strcmp(type_safe, "nopass") == 0)
+        snprintf(cmd, BUFSIZE, "WIFI:T:nopass;S:%s;;", ssid_safe);
+    else
+        snprintf(cmd, BUFSIZE, "WIFI:T:%s;S:%s;P:%s;;", type_safe, ssid_safe, pass_safe);
 
-    // if ((fp = popen(cmd, "r")) == NULL) {
-    //     printf("Error opening pipe!\n");
-        
-    // }
+    if (qr_to_png(cmd, qr_image_path) != 0)
+        return NULL;
 
-
-    // while (fgets(temp_buff, sizeof(temp_buff), fp) != NULL) {
-    
-    //     printf("%s", temp_buff);
-    // }
-
-    // if (pclose(fp)) {
-    //     printf("Error executing qrencode\n");
-        
-    // }
-
-    snprintf(cmd, BUFSIZE, "WIFI:S:%s;T:%s;P:%s;;",ssid,type,password);
-
-    qr_to_png(cmd,qr_image_path);
-    
     return qr_image_path;
 }
 

--- a/src/ui/qr_ui.c
+++ b/src/ui/qr_ui.c
@@ -31,29 +31,44 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #include <gtk/gtk.h>
+#include <unistd.h>
 #include "qr_ui.h"
 
-static GtkBuilder *builder;
-static GError *error = NULL;
+void open_qr(GtkWidget *widget, gpointer data, char *image_path) {
+    GtkBuilder *builder;
+    GtkWidget *dialog;
+    GtkImage *qr_image;
+    GError *error = NULL;
+    GtkWidget *toplevel;
 
-void open_qr(GtkWidget *widget, gpointer root,char* image_path) {
+    (void)data;
+
+    if (image_path == NULL || access(image_path, R_OK) != 0)
+        return;
 
     builder = gtk_builder_new();
-    //Load ui description from built resource - need to generate compiled source with glib-compile-resource
-    gtk_builder_add_from_resource(builder,"/org/gtk/wihotspot/qr.glade",&error);
+    if (!gtk_builder_add_from_resource(builder, "/org/gtk/wihotspot/qr.glade", &error)) {
+        g_warning("Failed to load QR dialog: %s", error ? error->message : "unknown");
+        g_clear_error(&error);
+        g_object_unref(builder);
+        return;
+    }
 
-    root = gtk_builder_get_object(builder, "dialog_qr");
+    dialog = GTK_WIDGET(gtk_builder_get_object(builder, "dialog_qr"));
+    qr_image = GTK_IMAGE(gtk_builder_get_object(builder, "image_qr"));
+    if (dialog == NULL || qr_image == NULL) {
+        g_object_unref(builder);
+        return;
+    }
 
-    GtkImage* qr_image = (GtkImage *) gtk_builder_get_object(builder, "image_qr");
+    if (widget != NULL) {
+        toplevel = gtk_widget_get_toplevel(widget);
+        if (GTK_IS_WINDOW(toplevel))
+            gtk_window_set_transient_for(GTK_WINDOW(dialog), GTK_WINDOW(toplevel));
+    }
 
-    gtk_image_set_from_file(qr_image,image_path);
-
-    GtkDialog* dialog= GTK_DIALOG(root);
-    
+    gtk_image_set_from_file(qr_image, image_path);
     gtk_dialog_run(GTK_DIALOG(dialog));
-
-    gtk_widget_destroy(GTK_WIDGET( dialog));
-    
-    g_signal_connect (dialog, "destroy", G_CALLBACK(gtk_main_quit), NULL);
-
+    gtk_widget_destroy(dialog);
+    g_object_unref(builder);
 }

--- a/src/ui/qrgen.cpp
+++ b/src/ui/qrgen.cpp
@@ -69,12 +69,23 @@ static unsigned int bg_color[4] = {255, 255, 255, 255};
 // return 0;
 // }
 
-void qr_to_png(const char *qrstring,const char *outfile){
-
+int qr_to_png(const char *qrstring,const char *outfile){
     QRcode *myqrcode;
-        myqrcode = QRcode_encodeString(qrstring, 4, QR_ECLEVEL_H, QR_MODE_8,1);
-        writePNG(myqrcode,outfile);
+
+    if (qrstring == NULL || outfile == NULL)
+        return -1;
+
+    myqrcode = QRcode_encodeString(qrstring, 4, QR_ECLEVEL_H, QR_MODE_8, 1);
+    if (myqrcode == NULL)
+        return -1;
+
+    if (writePNG(myqrcode, outfile) != 0) {
         QRcode_free(myqrcode);
+        return -1;
+    }
+
+    QRcode_free(myqrcode);
+    return 0;
 }
 
 
@@ -91,11 +102,14 @@ static int writePNG(QRcode *qrcode, const char *outfile)
     int x, y, xx, yy, bit;
     int realwidth;
 
+    if (qrcode == NULL || outfile == NULL)
+        return -1;
+
     realwidth = (qrcode->width + margin * 2) * size;
     row = (unsigned char *)malloc((realwidth + 7) / 8);
     if(row == NULL) {
         fprintf(stderr, "Failed to allocate memory.\n");
-        exit(EXIT_FAILURE);
+        return -1;
     }
 
     if(outfile[0] == '-' && outfile[1] == '\0') {
@@ -105,32 +119,47 @@ static int writePNG(QRcode *qrcode, const char *outfile)
         if(fp == NULL) {
             fprintf(stderr, "Failed to create file: %s\n", outfile);
             perror(NULL);
-            exit(EXIT_FAILURE);
+            free(row);
+            return -1;
         }
     }
 
     png_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
     if(png_ptr == NULL) {
         fprintf(stderr, "Failed to initialize PNG writer.\n");
-        exit(EXIT_FAILURE);
+        if (fp != stdout)
+            fclose(fp);
+        free(row);
+        return -1;
     }
 
     info_ptr = png_create_info_struct(png_ptr);
     if(info_ptr == NULL) {
         fprintf(stderr, "Failed to initialize PNG write.\n");
-        exit(EXIT_FAILURE);
+        png_destroy_write_struct(&png_ptr, NULL);
+        if (fp != stdout)
+            fclose(fp);
+        free(row);
+        return -1;
     }
 
     if(setjmp(png_jmpbuf(png_ptr))) {
         png_destroy_write_struct(&png_ptr, &info_ptr);
+        if (fp != stdout)
+            fclose(fp);
+        free(row);
         fprintf(stderr, "Failed to write PNG image.\n");
-        exit(EXIT_FAILURE);
+        return -1;
     }
 
     palette = (png_colorp) malloc(sizeof(png_color) * 2);
     if(palette == NULL) {
         fprintf(stderr, "Failed to allocate memory.\n");
-        exit(EXIT_FAILURE);
+        png_destroy_write_struct(&png_ptr, &info_ptr);
+        if (fp != stdout)
+            fclose(fp);
+        free(row);
+        return -1;
     }
     palette[0].red   = fg_color[0];
     palette[0].green = fg_color[1];
@@ -195,7 +224,8 @@ for(y=0; y<margin * size; y++) {
 png_write_end(png_ptr, info_ptr);
 png_destroy_write_struct(&png_ptr, &info_ptr);
 
-fclose(fp);
+if (fp != stdout)
+    fclose(fp);
 free(row);
 free(palette);
 

--- a/src/ui/qrgen.h
+++ b/src/ui/qrgen.h
@@ -41,7 +41,7 @@ extern "C" {
 
 static int writePNG(QRcode *qrcode, const char *outfile);
 
-void qr_to_png(const char *qrstring,const char *outfile);
+int qr_to_png(const char *qrstring,const char *outfile);
 
 #ifdef __cplusplus
 }

--- a/src/ui/ui.c
+++ b/src/ui/ui.c
@@ -185,7 +185,16 @@ static void on_about_open_click(GtkWidget *widget, gpointer data){
 
 static void on_qr_open_click(GtkWidget *widget, gpointer data){
 
-    char* image_path = generate_qr_image(configValues.ssid,"WPA",configValues.pass);
+    // an open network has to be encoded as nopass, otherwise phones reject the code
+    char *type = (configValues.pass == NULL || configValues.pass[0] == '\0') ? "nopass" : "WPA";
+
+    char* image_path = generate_qr_image(configValues.ssid, type, configValues.pass);
+
+    if (image_path == NULL) {
+        set_error_text("Could not generate the QR code");
+        return;
+    }
+
     open_qr(widget,data,image_path);
 }
 


### PR DESCRIPTION
Ports the backend and low-risk GUI fixes from #519 (by @syd168) onto current `master`, resolving the conflicts and leaving out two changes that would regress behaviour. Full review of the original is in [this comment](https://github.com/lakinduakash/linux-wifi-hotspot/pull/519#issuecomment-5516433981).

Original commits are credited via `Co-Authored-By`.

## What's included

**`create_ap` — orphaned and duplicate hotspot state**
A crashed or force-killed run leaves its confdir, a stale `ap*` interface and sometimes a live `dnsmasq` behind; the next attempt then dies on "Creating a virtual WiFi interface" with no explanation. Now orphans are cleared before starting, stale AP interfaces on the same phy are removed (but never one whose create_ap is still alive), starting a second hotspot on a busy interface fails with the command to stop it, and `--stop` accepts a PID or an interface, waits, forces if needed, then sweeps.

Also fixes a lock leak: `has_running_instance()` ended with `mutex_lock` instead of `mutex_unlock`, so the "nothing running" path returned still holding the global mutex.

**`create_ap` — gateway subnet conflicts**
`192.168.12.1` was handed out unconditionally. When the upstream network already uses that subnet, NAT and routing collide with it. Now detected against the default route and local addresses, with a fallback to the first free candidate.

**`create_ap` — channel defaults**
`FREQ_BAND` can be `default` since 281d905, and the `else` branch mapped anything not `2.4` to channel 36 — a 5 GHz channel for an unknown band. Also guards the "cannot transmit to channel" fallback against an unset `$WIFI_IFACE_CHANNEL`, which previously produced an empty channel instead of a clear error.

**`create_ap --show-info`**
Reports SSID, encryption, passphrase, gateway, channel, band, hidden and the interfaces of a running hotspot as `KEY=VALUE`, from a PID or an interface name.

**GUI — QR code fixes**
`writePNG()` called `exit(EXIT_FAILURE)`, so a failed QR write killed the whole GUI. `qr_ui.c` destroyed the dialog and *then* connected a `destroy` handler to it, and leaked the builder on every open. `generate_qr_image()` had no NULL checks and wrote a single `/tmp/wihotspot_qr.png` shared by every account on the machine. Open networks were encoded as `WPA` with an empty `P:` field, which phones reject — now `WIFI:T:nopass;S:<ssid>;;`.

**`wihotspot` launcher**
Drops back to `$SUDO_USER` when started with `sudo`, carrying `DISPLAY`, `XAUTHORITY` and `DBUS_SESSION_BUS_ADDRESS`.

## What's deliberately left out

- **Redirecting hostapd to a log file and `exec >/dev/null`.** This silences the GUI's live status feed and disables the handshake-failure watchdog added in #525, and it prints `AP-ENABLED` one second in regardless of whether hostapd survives — so a hotspot that fails at t=2s reports success and then vanishes silently. The SIGPIPE concern behind it was already fixed from the other end in #525.
- **`chmod 444` on `hostapd.conf`.** `SCRIPT_UMASK=0077` keeps that file `0600`, and `CONFDIR` is `755` and traversable, so this would make the WiFi passphrase readable by every local user at a predictable path. `--show-info` (included here) is the safe way to get the same data.
- **The Active Hotspots list UI and the threading rework.** Worth having, but the `g_idle_add` restructuring in #519 is interwoven with the list widgets, so it isn't separable without rewriting it. Both need interactive testing, so they belong in their own PR.
- **The `sync_channel_with_wifi_connection` refactor.** Reasonable, and it handles the `FREQ_BAND_SET=1` case the old code ignored, but master's equivalent block was repaired in #525 (`${IFACE}` was unset, so the multi-channel probe never matched). Deferring to avoid churning working channel logic in a port.

## Testing

On a PCIe `brcmfmac` (BCM4364), connected as a station throughout:

- Full hotspot cycle with the ported script: reaches `AP-ENABLED`, hostapd output still streams through the #525 watchdog, station link and internet unaffected.
- `--show-info wlp5s0` against a live hotspot returns correct SSID / WPA2-PSK / gateway / channel 149 / 5 GHz / interfaces.
- Duplicate-start guard: second `create_ap` on the same interface exits 1 with the stop hint.
- `--stop <iface>`: removes `ap0`, the confdir and the NAT rules; `nmcli` shows the interface managed again and internet still up.
- Gateway conflict: `-g 192.168.1.1` on a machine with `192.168.1.9/24` correctly warns and falls back to `192.168.43.1`, and the AP still comes up.
- `--show-info` / `--stop` against a non-existent hotspot exit cleanly with sensible messages.
- QR generation exercised against the compiled objects: WPA and `nopass` both produce a valid 344x344 PNG; NULL ssid/type/password and empty SSID return NULL without crashing.
- `make` clean with no new warnings, `./build/test` passes, all three intermediate `create_ap` commits pass `bash -n`, GUI launches.

Not verified: the GUI's create/stop buttons interactively, and `--show-info` from the GUI (no consumer in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
