### PR TITLE
Fix channel/band selection on single-channel AP adapters, and make 5GHz work on Intel

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 
 
 ### What's new
+* The GUI now shows the full `create_ap` log in a scrollable box instead of just the last line ([#527](https://github.com/lakinduakash/linux-wifi-hotspot/pull/527))
 * 5GHz hotspots now work on Intel adapters - new [guide and helper scripts](docs/howto/intel-5ghz-lar.md) to restore the removed `iwlwifi` `lar_disable` parameter ([#527](https://github.com/lakinduakash/linux-wifi-hotspot/pull/527))
 * The hotspot now follows the channel your WiFi client is on instead of failing with `Failed to set beacon parameters` ([#527](https://github.com/lakinduakash/linux-wifi-hotspot/pull/527))
 * Frequency band selection in the GUI no longer silently falls back to 2.4GHz ([#527](https://github.com/lakinduakash/linux-wifi-hotspot/pull/527))

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@
 
 
 ### What's new
+* 5GHz hotspots now work on Intel adapters - new [guide and helper scripts](docs/howto/intel-5ghz-lar.md) to restore the removed `iwlwifi` `lar_disable` parameter ([#527](https://github.com/lakinduakash/linux-wifi-hotspot/pull/527))
+* The hotspot now follows the channel your WiFi client is on instead of failing with `Failed to set beacon parameters` ([#527](https://github.com/lakinduakash/linux-wifi-hotspot/pull/527))
+* Frequency band selection in the GUI no longer silently falls back to 2.4GHz ([#527](https://github.com/lakinduakash/linux-wifi-hotspot/pull/527))
+* `--ieee80211ac` can now actually reach 80MHz, with the new `--vht-chwidth` option ([#527](https://github.com/lakinduakash/linux-wifi-hotspot/pull/527))
 * Errors from `create_ap` are now shown in the GUI instead of failing silently ([#525](https://github.com/lakinduakash/linux-wifi-hotspot/pull/525))
 * WiFi and Internet interfaces are preselected, so hotspot creation works out of the box ([#525](https://github.com/lakinduakash/linux-wifi-hotspot/pull/525))
 * Virtual interfaces are no longer refused on PCIe/USB `brcmfmac` adapters ([#525](https://github.com/lakinduakash/linux-wifi-hotspot/pull/525))
@@ -50,7 +54,9 @@ If you only need the command line without GUI run `make install-cli-only` as the
 
 ### Notes
 
-- Sometimes there are troubles with **5Ghz bands** due to some vendor restrictions. If you cannot start the hotspot while you are connected to the 5Ghz band, Unselect **Auto** and select **2.4Ghz** in frequency selection.
+- **5Ghz hotspot will not start:** on Intel (`iwlwifi`) adapters this is almost always the adapter's firmware keeping every 5GHz channel flagged `no IR`, which forbids beaconing. See [5GHz hotspots on Intel adapters](docs/howto/intel-5ghz-lar.md) - it explains how to confirm it and includes scripts that fix it. As a quick workaround, unselect **Auto** and select **2.4Ghz** in frequency selection.
+
+- **`Failed to set beacon parameters`:** many adapters can only host an access point on the channel their WiFi client is already using, so the hotspot follows your current connection. Connect to a 2.4GHz network for a 2.4GHz hotspot, or a 5GHz one for 5GHz. See [the same guide](docs/howto/intel-5ghz-lar.md#the-other-restriction-one-channel-at-a-time).
 
 - If any problems with **RealTeK Wifi Adapters** see [this](docs/howto/realtek.md)
 

--- a/docs/howto/intel-5ghz-lar.md
+++ b/docs/howto/intel-5ghz-lar.md
@@ -1,0 +1,202 @@
+# 5GHz hotspots on Intel adapters (iwlwifi)
+
+Most "I cannot start a 5GHz hotspot" reports on Intel cards come down to two
+*separate* restrictions. They have different causes and different answers, so
+work out which one you are hitting before changing anything.
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| `Your adapter can not transmit to channel 36, frequency band 5GHz` | every 5GHz channel is flagged `no IR` | [disable LAR](#disabling-lar) |
+| `Failed to set beacon parameters` / `Interface initialization failed` | the AP must share the channel your WiFi client is on | nothing to do, `create_ap` now handles it |
+
+## Which one am I hitting?
+
+```
+iw reg get | head -5
+iw phy "$(iw dev | awk '/^phy#/{gsub("#","");print $1;exit}')" info | grep 'MHz \[' | grep '5[0-9]\{3\}'
+```
+
+If the output looks like this, you have the regulatory problem:
+
+```
+phy#0 (self-managed)
+country 00: DFS-UNSET
+...
+	* 5180.0 MHz [36] (22.0 dBm) (no IR)
+	* 5745.0 MHz [149] (22.0 dBm) (no IR)
+```
+
+Two things matter: **`(self-managed)`** and **`(no IR)`** on every 5GHz channel.
+
+## Why it happens
+
+Intel adapters use LAR (Location Aware Regulatory). The regulatory domain lives
+in the adapter firmware rather than in the kernel's `regulatory.db`, and the
+wiphy is marked *self-managed*. When the firmware has not learned a country it
+sits on the world domain `country 00`, where every 5GHz channel carries `no IR`.
+
+**IR** is "Initiate Radiation". `no IR` means you may not start transmitting on
+that channel on your own initiative - you may only answer something already
+there. That is exactly the difference between a client and an access point:
+
+* joining a 5GHz network works, because a client listens first and only then
+  replies;
+* hosting does not, because an access point beacons unprompted.
+
+So on an affected card you can *connect* over 5GHz but never *host* on it.
+
+Things that do **not** help:
+
+* `iw reg set XX` - a self-managed wiphy ignores it. The country comes from
+  firmware.
+* Being associated to a router that broadcasts a Country IE - the firmware
+  often still stays on `country 00`.
+* The kernel's `IR-CONCURRENT` relaxation, which allows beaconing on a `no IR`
+  channel while already associated on it. It is unusable twice over:
+  `CONFIG_CFG80211_REG_RELAX_NO_IR` depends on `CFG80211_CERTIFICATION_ONUS`,
+  which distributions do not enable, and even when built in,
+  `cfg80211_ir_permissive_chan()` only allows `P2P_GO`, `STATION` and
+  `P2P_CLIENT`. A plain AP interface is excluded.
+
+## Disabling LAR
+
+`iwlwifi` used to ship a `lar_disable=1` module parameter for exactly this, and
+it was removed. The scripts in [`util/iwlwifi-lar-disable/`](../../util/iwlwifi-lar-disable)
+put it back: a two file patch to `iwlmvm` that stops the driver claiming a
+self-managed regulatory domain, so the kernel database applies and `iw reg set`
+starts working.
+
+> **This moves regulatory responsibility to you.** Set the country you are
+> actually in and only operate on channels your regulator permits. Disabling
+> LAR does not grant you spectrum, it just stops the firmware being
+> conservative.
+
+### 1. Build
+
+```
+cd util/iwlwifi-lar-disable
+./build.sh
+```
+
+It needs your kernel headers and kernel source. On Debian/Ubuntu it installs
+`linux-source-*` itself; elsewhere install your distribution's kernel source
+package, or point it at an unpacked tree:
+
+```
+KERNEL_SRC=/path/to/linux ./build.sh
+```
+
+### 2. Enroll a signing key (Secure Boot only)
+
+If Secure Boot is on, `build.sh` signs the module and prints the enrollment
+command. Unsigned modules are refused, so this step is not optional:
+
+```
+sudo mokutil --import /var/lib/linux-wifi-hotspot/lar/MOK.der
+```
+
+Pick a one-time password and reboot. A blue **MOK Manager** screen appears
+before the OS loads:
+
+1. press a key at the *"Press any key to perform MOK management"* countdown -
+   letting it expire silently discards the request, which is the single most
+   common reason this step fails;
+2. `Enroll MOK` -> `Continue` -> `Yes`;
+3. type the password from above (US keyboard layout);
+4. `Reboot`.
+
+### 3. Install
+
+```
+sudo COUNTRY=LK ./install.sh     # use your own two letter country code
+sudo reboot
+```
+
+`install.sh` refuses to run while the key is unenrolled, so there is never a
+boot with an unloadable WiFi module.
+
+### 4. Verify
+
+```
+iw reg get | head -3
+```
+
+The per-phy `(self-managed)` block should be gone and the country should be
+yours. Then:
+
+```
+iw phy "$(iw dev | awk '/^phy#/{gsub("#","");print $1;exit}')" info | grep 'MHz \[' | grep '5[0-9]\{3\}'
+```
+
+The `(no IR)` suffix should have disappeared from the non-DFS channels. Connect
+to a 5GHz network and start the hotspot as usual - `create_ap` puts the AP on
+the channel your client is already using.
+
+### Reverting
+
+```
+sudo util/iwlwifi-lar-disable/uninstall.sh
+sudo reboot
+```
+
+## After a kernel upgrade
+
+The module is installed into `/lib/modules/<version>/updates/`, so a new kernel
+loads the distribution module again and 5GHz hotspots stop working. Nothing
+breaks, but you have to rebuild:
+
+```
+cd util/iwlwifi-lar-disable && ./build.sh && sudo COUNTRY=LK ./install.sh
+```
+
+The signing key stays enrolled across kernel upgrades, so only the build and
+install steps repeat.
+
+## The other restriction: one channel at a time
+
+Independently of any of the above, since Linux 6.11 `iwlwifi` only advertises AP
+mode in a single-channel interface combination (kernel commit `5c38bedac16a`):
+
+```
+* #{ managed } <= 1, #{ P2P-client, P2P-GO } <= 1, ...  #channels <= 2   <- no AP
+* #{ managed } <= 1, #{ AP, P2P-client, P2P-GO } <= 1,  #channels <= 1   <- the AP one
+```
+
+The access point therefore has to sit on **the same channel your WiFi client is
+connected to**. Asking for anything else gets you hostapd's
+`Failed to set beacon parameters`.
+
+`create_ap` reads this out of the driver and follows the client's channel
+automatically, so in practice:
+
+* connected to a 2.4GHz network -> you get a 2.4GHz hotspot;
+* connected to a 5GHz network -> you get a 5GHz hotspot on that channel;
+* asking for a band the client is not on is refused with an explanation.
+
+This is a hardware and driver limitation. Disabling LAR does not change it, and
+there is no `create_ap` option that works around it. To host on a specific
+channel, connect the client to a network on that channel, or share a different
+uplink such as ethernet.
+
+## Channel width
+
+Some regulatory domains cap 5GHz channels at 20MHz in the kernel database even
+where the firmware previously allowed 80MHz, so disabling LAR can narrow both
+the hotspot *and* your normal client connection. Check with:
+
+```
+iw reg get
+```
+
+A rule like `(5735 - 5835 @ 20)` means 20MHz maximum; `@ 80` means 80MHz is
+available. `create_ap --ieee80211ac --vht-chwidth 80` asks for 80MHz and
+automatically falls back to whatever the regulatory domain allows, reporting
+what it settled on. If your country's entry looks wrong, the fix belongs
+upstream in [wireless-regdb](https://git.kernel.org/pub/scm/linux/kernel/git/sforshee/wireless-regdb.git).
+
+## Non-Intel adapters
+
+This guide is specific to `iwlwifi`. Realtek users should see
+[realtek.md](realtek.md). Adapters from other vendors that report a
+self-managed regulatory domain have the same underlying problem but need a
+driver-specific change; the diagnosis section above still applies.

--- a/docs/howto/intel-5ghz-lar.md
+++ b/docs/howto/intel-5ghz-lar.md
@@ -9,6 +9,16 @@ work out which one you are hitting before changing anything.
 | `Your adapter can not transmit to channel 36, frequency band 5GHz` | every 5GHz channel is flagged `no IR` | [disable LAR](#disabling-lar) |
 | `Failed to set beacon parameters` / `Interface initialization failed` | the AP must share the channel your WiFi client is on | nothing to do, `create_ap` now handles it |
 
+> **The fix here only covers `iwlmvm` adapters.** Check which Intel driver you
+> have before going further:
+>
+> ```
+> lsmod | grep -E '^iwl(dvm|mvm|mld)'
+> ```
+>
+> See [Scope and limitations](#scope-and-limitations) — the diagnosis applies
+> more widely than the fix does.
+
 ## Which one am I hitting?
 
 ```
@@ -194,7 +204,56 @@ automatically falls back to whatever the regulatory domain allows, reporting
 what it settled on. If your country's entry looks wrong, the fix belongs
 upstream in [wireless-regdb](https://git.kernel.org/pub/scm/linux/kernel/git/sforshee/wireless-regdb.git).
 
-## Non-Intel adapters
+## Scope and limitations
+
+`iwlwifi` hands your card to one of three operating-mode modules, and they set
+the regulatory flags differently. Only one of them is fixable this way.
+
+```
+lsmod | grep -E '^iwl(dvm|mvm|mld)'
+```
+
+### `iwlmvm` — supported
+
+Roughly 7260/3160/7265 and everything newer up to the AX2xx parts. It only marks
+the wiphy self-managed when LAR is available:
+
+```c
+if (iwl_mvm_is_lar_supported(mvm))
+        hw->wiphy->regulatory_flags |= REGULATORY_WIPHY_SELF_MANAGED;
+```
+
+That test is what `lar_disable.patch` hooks into, so the scripts here work.
+
+### `iwlmld` — not supported yet
+
+The newest Wi-Fi 7 parts. `iwl_mld_hw_set_regulatory()` sets the flag
+unconditionally:
+
+```c
+wiphy->regulatory_flags |= REGULATORY_WIPHY_SELF_MANAGED;
+wiphy->regulatory_flags |= REGULATORY_ENABLE_RELAX_NO_IR;
+```
+
+There is no LAR test to switch off, so a `lar_disable` parameter would have
+nothing to do. Making these cards behave would mean dropping the flag outright,
+which is a broader change than this patch makes. The diagnosis above still
+explains the symptom; the fix does not apply.
+
+### `iwldvm` — not affected
+
+The older Centrino-era parts. They never claim a self-managed domain at all:
+
+```c
+hw->wiphy->regulatory_flags |= REGULATORY_CUSTOM_REG | ...
+```
+
+`iw reg get` will not print `(self-managed)` for these. If you are on `iwldvm`
+and 5GHz still fails, this guide is not your problem — look at whether the
+adapter advertises AP mode at all (`iw list | grep -A10 'Supported interface
+modes'`), and at the [single-channel restriction](#the-other-restriction-one-channel-at-a-time).
+
+### Non-Intel adapters
 
 This guide is specific to `iwlwifi`. Realtek users should see
 [realtek.md](realtek.md). Adapters from other vendors that report a

--- a/src/scripts/create_ap
+++ b/src/scripts/create_ap
@@ -331,6 +331,51 @@ can_be_sta_and_ap() {
     return 1
 }
 
+# Largest number of distinct channels the adapter allows in an interface
+# combination that actually contains an AP. Drivers commonly advertise several
+# combinations and only some of them permit AP mode, so the AP ones have to be
+# picked out before reading "#channels" - a plain grep over the whole block
+# happily matches a multi-channel combination that can not hold an AP at all.
+# Prints nothing when the information is unavailable.
+get_ap_max_channels() {
+    [[ $USE_IWCONFIG -eq 1 ]] && return 0
+    get_adapter_info "$1" 2>/dev/null | awk '
+        /valid interface combinations:/ { comb = 1; next }
+        !comb { next }
+        # a line indented with a single tab ends the combination list
+        /^\t[^\t]/ { comb = 0; next }
+        {
+            if ($0 ~ /^[[:space:]]*\*/) {
+                if (rec != "") print rec
+                rec = $0
+            } else if (rec != "") {
+                rec = rec " " $0
+            }
+        }
+        END { if (rec != "") print rec }
+    ' | grep -E '#\{[^}]*\bAP\b[^}]*\}' \
+      | sed -n 's/.*#channels <= \([0-9]\+\).*/\1/p' \
+      | sort -n | tail -1
+}
+
+# Every 5GHz channel is reported as "no IR" while the adapter uses a
+# self-managed (LAR) regulatory domain that is still on the world domain 00.
+# Nothing in userspace can lift that, so explain it instead of only reporting
+# that the channel is unusable.
+regdomain_hint() {
+    local PHY
+    [[ $USE_IWCONFIG -eq 1 ]] && return 0
+    PHY=$(get_phy_device "$1" 2>/dev/null) || return 0
+    iw reg get 2>/dev/null | grep -A1 "^phy#${PHY#phy} (self-managed)" |
+        grep -q "^country 00:" || return 0
+    echo "
+       ${PHY} uses a self-managed regulatory domain and is still on the world
+       domain (country 00), where every 5GHz channel is flagged 'no IR' and can
+       not carry an access point. 'iw reg set' does not change this, the value
+       comes from the adapter's own firmware. 2.4GHz is unaffected, so run the
+       hotspot with --freq-band 2.4."
+}
+
 can_be_ap() {
     # iwconfig does not provide this information, assume true
     [[ $USE_IWCONFIG -eq 1 ]] && return 0
@@ -1427,6 +1472,14 @@ elif [[ $RUNNING_AS_DAEMON -eq 1 && -n "$DAEMON_PIDFILE" ]]; then
     echo $$ >$DAEMON_PIDFILE
 fi
 
+# --mkconfig (and the GUI) store FREQ_BAND=default when no band was requested.
+# Normalise it back to the built-in default, otherwise the literal string
+# "default" falls through every 2.4GHz comparison below and the hotspot ends up
+# on 5GHz channel 36 without anyone asking for it.
+if [[ $FREQ_BAND == default ]]; then
+    FREQ_BAND=2.4
+fi
+
 if [[ $FREQ_BAND_SET != 0 ]]; then
     if [[ $FREQ_BAND != 2.4 && $FREQ_BAND != 5 ]]; then
         echo "ERROR: Invalid frequency band" >&2
@@ -1671,29 +1724,46 @@ if [[ $NO_VIRT -eq 0 ]]; then
     fi
 
 
-    if is_wifi_connected ${WIFI_IFACE} && [[ $FREQ_BAND_SET -eq 0 ]]; then
+    if is_wifi_connected ${WIFI_IFACE}; then
         WIFI_IFACE_FREQ=$(iw dev ${WIFI_IFACE} link | grep -i freq | awk '{print $2}')
         WIFI_IFACE_CHANNEL=$(ieee80211_frequency_to_channel ${WIFI_IFACE_FREQ})
-        echo -n "${WIFI_IFACE} is already associated with channel ${WIFI_IFACE_CHANNEL} (${WIFI_IFACE_FREQ} MHz)"
         if is_5ghz_frequency $WIFI_IFACE_FREQ; then
-            FREQ_BAND=5
+            WIFI_IFACE_BAND=5
         else
-            FREQ_BAND=2.4
+            WIFI_IFACE_BAND=2.4
         fi
-        if [[ $WIFI_IFACE_CHANNEL -ne $CHANNEL ]]; then
-            if ( get_adapter_info ${WIFI_IFACE} | grep "#channels <= 2" -q )
-            then
-                echo -e "\nmultiple channels supported"
-            else
-                echo -e  "\nmultiple channels not supported",
-                echo -e  "\nfallback to channel ${WIFI_IFACE_CHANNEL}"
-                CHANNEL=$WIFI_IFACE_CHANNEL
+        echo "${WIFI_IFACE} is already associated with channel ${WIFI_IFACE_CHANNEL} (${WIFI_IFACE_FREQ} MHz)"
+
+        AP_MAX_CHANNELS=$(get_ap_max_channels ${WIFI_IFACE})
+
+        if [[ "$AP_MAX_CHANNELS" == 1 && $WIFI_IFACE_CHANNEL -ne $CHANNEL ]]; then
+            # The adapter only offers AP mode in single-channel interface
+            # combinations, so the AP has to sit on the channel the station half
+            # already uses. iwlwifi behaves this way since Linux 6.11, see
+            # https://github.com/lakinduakash/linux-wifi-hotspot/issues/435
+            # Without this hostapd only reports "Failed to set beacon parameters".
+            if [[ $USING_DEFAULT_CHANNEL -eq 0 ]] ||
+               [[ $FREQ_BAND_SET -eq 1 && $FREQ_BAND != $WIFI_IFACE_BAND ]]; then
+                die "Your adapter can only run an access point on the channel it is already
+       connected to, but a different channel was requested.
+
+           requested: channel ${CHANNEL} (${FREQ_BAND}GHz)
+           connected: channel ${WIFI_IFACE_CHANNEL} (${WIFI_IFACE_BAND}GHz) on ${WIFI_IFACE}
+
+       Use one of these instead:
+         * run the hotspot on the channel already in use:
+               --freq-band ${WIFI_IFACE_BAND} -c ${WIFI_IFACE_CHANNEL}
+         * connect ${WIFI_IFACE} to a network on channel ${CHANNEL} first
+         * disconnect ${WIFI_IFACE} and share a different uplink (e.g. ethernet)"
             fi
-        else
-            echo "channel------------------ ${CHANNEL}"
+            echo "Adapter supports the AP on one channel only, following ${WIFI_IFACE} to channel ${WIFI_IFACE_CHANNEL}"
+            CHANNEL=$WIFI_IFACE_CHANNEL
+            FREQ_BAND=$WIFI_IFACE_BAND
+        elif [[ $FREQ_BAND_SET -eq 0 ]]; then
+            # Multi-channel capable adapter: keep following the station's band
+            # when no specific band was requested.
+            FREQ_BAND=$WIFI_IFACE_BAND
         fi
-    elif is_wifi_connected ${WIFI_IFACE} && [[ $FREQ_BAND_SET -eq 1 ]]; then
-        echo "Custom frequency band set with ${FREQ_BAND}Ghz with channel ${CHANNEL}"
     fi
 
 
@@ -1731,13 +1801,17 @@ fi
 if can_transmit_to_channel "${WIFI_IFACE}" "${CHANNEL}"; then
     echo "Transmitting to channel ${CHANNEL}..."
 else
-    if [[ $USING_DEFAULT_CHANNEL -eq 1 && $WIFI_IFACE_CHANNEL -ne $CHANNEL ]]; then
+    # WIFI_IFACE_CHANNEL is only set when the adapter is associated. Without the
+    # emptiness test the comparison below evaluates it as 0, so a disconnected
+    # adapter "falls back" to an empty channel:
+    # https://github.com/lakinduakash/linux-wifi-hotspot/issues/206
+    if [[ $USING_DEFAULT_CHANNEL -eq 1 && -n "$WIFI_IFACE_CHANNEL" && $WIFI_IFACE_CHANNEL -ne $CHANNEL ]]; then
         echo -e "Your adapter can not transmit to channel ${CHANNEL}" >&2
         CHANNEL=$WIFI_IFACE_CHANNEL
         echo -e "Falling back to channel ${CHANNEL}"
-        can_transmit_to_channel "${WIFI_IFACE}" "${CHANNEL}" || die "Your adapter can not transmit to channel ${CHANNEL}, frequency band ${FREQ_BAND}GHz."
+        can_transmit_to_channel "${WIFI_IFACE}" "${CHANNEL}" || die "Your adapter can not transmit to channel ${CHANNEL}, frequency band ${FREQ_BAND}GHz.$(regdomain_hint ${WIFI_IFACE})"
     else
-        die "Your adapter can not transmit to channel ${CHANNEL}, frequency band ${FREQ_BAND}GHz."
+        die "Your adapter can not transmit to channel ${CHANNEL}, frequency band ${FREQ_BAND}GHz.$(regdomain_hint ${WIFI_IFACE})"
     fi
 fi
 

--- a/src/scripts/create_ap
+++ b/src/scripts/create_ap
@@ -53,6 +53,9 @@ usage() {
     echo "  --ieee80211ax           Enable IEEE 802.11ax (VHT)"
     echo "  --ht_capab <HT>         HT capabilities (default: [HT40+])"
     echo "  --vht_capab <VHT>       VHT capabilities"
+    echo "  --vht-chwidth <MHz>     Channel width to aim for on 5GHz with --ieee80211ac."
+    echo "                          Valid inputs: 20, 40, 80, 160 (default: 80). Capped to"
+    echo "                          what the regulatory domain allows."
     echo "  --country <code>        Set two-letter country code for regularity (example: US)"
     echo "  --freq-band <GHz>       Set frequency band. Valid inputs: 2.4, 5 (default: Use 5GHz if the interface supports it)"
     echo "  --driver                Choose your WiFi adapter driver (default: nl80211)"
@@ -374,6 +377,52 @@ regdomain_hint() {
        not carry an access point. 'iw reg set' does not change this, the value
        comes from the adapter's own firmware. 2.4GHz is unaffected, so run the
        hotspot with --freq-band 2.4."
+}
+
+# Widest channel (MHz) the active regulatory domain permits at a frequency.
+# iw reg get can print both a global and a per-phy section, so take the most
+# restrictive rule that covers the frequency. Prints nothing when unknown.
+get_max_regulatory_bw() {
+    local FREQ=$1
+    iw reg get 2>/dev/null | tr -d '\t' |
+        sed -n 's/^(\([0-9]\+\) - \([0-9]\+\) @ \([0-9]\+\)).*/\1 \2 \3/p' |
+        while read -r LO HI BW; do
+            [[ $FREQ -ge $LO && $FREQ -le $HI ]] && echo "$BW"
+        done | sort -n | head -1
+}
+
+# VHT centre frequency index for the 80 or 160MHz block holding a 5GHz channel.
+get_vht_seg0_idx() {
+    local CH=$1 WIDTH=$2
+    if [[ $WIDTH -eq 80 ]]; then
+        case $CH in
+            36|40|44|48)        echo 42  ;;
+            52|56|60|64)        echo 58  ;;
+            100|104|108|112)    echo 106 ;;
+            116|120|124|128)    echo 122 ;;
+            132|136|140|144)    echo 138 ;;
+            149|153|157|161)    echo 155 ;;
+            165|169|173|177)    echo 171 ;;
+        esac
+    elif [[ $WIDTH -eq 160 ]]; then
+        case $CH in
+            36|40|44|48|52|56|60|64)             echo 50  ;;
+            100|104|108|112|116|120|124|128)     echo 114 ;;
+            149|153|157|161|165|169|173|177)     echo 163 ;;
+        esac
+    fi
+}
+
+# Each 5GHz 40MHz pair has a fixed layout: the lower channel takes its
+# secondary above (HT40+), the upper one below (HT40-). Getting this backwards
+# leaves hostapd on a 20MHz channel.
+get_ht40_direction() {
+    # printf, not echo: a lone "-" is swallowed as an end-of-options marker by
+    # some shells' echo builtins
+    case $1 in
+        36|44|52|60|100|108|116|124|132|140|149|157|165|173) printf '+' ;;
+        40|48|56|64|104|112|120|128|136|144|153|161|169|177) printf '-' ;;
+    esac
 }
 
 can_be_ap() {
@@ -731,6 +780,7 @@ IEEE80211AC=0
 IEEE80211AX=0
 HT_CAPAB='[HT40+]'
 VHT_CAPAB=
+VHT_CHWIDTH=80
 DRIVER=nl80211
 NO_VIRT=0
 COUNTRY=
@@ -747,7 +797,7 @@ HOSTAPD_DEBUG_ARGS=
 REDIRECT_TO_LOCALHOST=0
 
 CONFIG_OPTS=(CHANNEL GATEWAY WPA_VERSION ETC_HOSTS DHCP_DNS NO_DNS NO_DNSMASQ HIDDEN MAC_FILTER MAC_FILTER_ACCEPT ISOLATE_CLIENTS
-             SHARE_METHOD IEEE80211N IEEE80211AC IEEE80211AX HT_CAPAB VHT_CAPAB DRIVER NO_VIRT COUNTRY FREQ_BAND
+             SHARE_METHOD IEEE80211N IEEE80211AC IEEE80211AX HT_CAPAB VHT_CAPAB VHT_CHWIDTH DRIVER NO_VIRT COUNTRY FREQ_BAND
              NEW_MACADDR DAEMONIZE DAEMON_PIDFILE DAEMON_LOGFILE DNS_LOGFILE NO_HAVEGED WIFI_IFACE INTERNET_IFACE
              SSID PASSPHRASE USE_PSK ADDN_HOSTS DHCP_HOSTS)
 
@@ -1174,7 +1224,7 @@ for ((i=0; i<$#; i++)); do
     fi
 done
 
-GETOPT_ARGS=$(getopt -o hc:w:g:de:nm: -l "help","hidden","hostapd-debug:","hostapd-timestamps","redirect-to-localhost","mac-filter","mac-filter-accept:","isolate-clients","ieee80211n","ieee80211ac","ieee80211ax","ht_capab:","vht_capab:","driver:","no-virt","fix-unmanaged","country:","freq-band:","mac:","dhcp-dns:","daemon","pidfile:","logfile:","dns-logfile:","stop:","list","list-running","list-clients:","version","psk","no-haveged","no-dns","no-dnsmasq","mkconfig:","config:","dhcp-hosts:" -n "$PROGNAME" -- "$@")
+GETOPT_ARGS=$(getopt -o hc:w:g:de:nm: -l "help","hidden","hostapd-debug:","hostapd-timestamps","redirect-to-localhost","mac-filter","mac-filter-accept:","isolate-clients","ieee80211n","ieee80211ac","ieee80211ax","ht_capab:","vht_capab:","vht-chwidth:","driver:","no-virt","fix-unmanaged","country:","freq-band:","mac:","dhcp-dns:","daemon","pidfile:","logfile:","dns-logfile:","stop:","list","list-running","list-clients:","version","psk","no-haveged","no-dns","no-dnsmasq","mkconfig:","config:","dhcp-hosts:" -n "$PROGNAME" -- "$@")
 [[ $? -ne 0 ]] && exit 1
 eval set -- "$GETOPT_ARGS"
 
@@ -1264,6 +1314,11 @@ while :; do
         --vht_capab)
             shift
             VHT_CAPAB="$1"
+            shift
+            ;;
+        --vht-chwidth)
+            shift
+            VHT_CHWIDTH="$1"
             shift
             ;;
         --driver)
@@ -1865,6 +1920,39 @@ accept_mac_file=${MAC_FILTER_ACCEPT}
 EOF
 fi
 
+# Work out how wide the channel can actually be. hostapd stays on a 20/40MHz
+# channel unless it is told the VHT operating width and centre frequency index,
+# so "ieee80211ac=1" on its own never gets past 40MHz. Whatever is asked for is
+# capped to what the regulatory domain allows, so an over-wide request degrades
+# instead of leaving hostapd unable to start.
+EFFECTIVE_BW=20
+if [[ $FREQ_BAND == 5 ]] && [[ $IEEE80211N -eq 1 || $IEEE80211AC -eq 1 ]]; then
+    case $VHT_CHWIDTH in
+        20|40|80|160) EFFECTIVE_BW=$VHT_CHWIDTH ;;
+        *) echo "WARN: invalid --vht-chwidth '${VHT_CHWIDTH}', using 80" >&2
+           EFFECTIVE_BW=80 ;;
+    esac
+
+    # 802.11n tops out at 40MHz; 80 and 160 need VHT
+    [[ $IEEE80211AC -eq 0 && $EFFECTIVE_BW -gt 40 ]] && EFFECTIVE_BW=40
+
+    REG_BW=$(get_max_regulatory_bw $((5000 + CHANNEL * 5)))
+    if [[ -n "$REG_BW" && $REG_BW -lt $EFFECTIVE_BW ]]; then
+        echo "Regulatory domain limits channel ${CHANNEL} to ${REG_BW} MHz wide, using that instead of ${EFFECTIVE_BW} MHz"
+        EFFECTIVE_BW=$REG_BW
+    fi
+
+    HT40_DIR=$(get_ht40_direction ${CHANNEL})
+    if [[ $EFFECTIVE_BW -ge 40 && -n "$HT40_DIR" ]]; then
+        HT_CAPAB=${HT_CAPAB//\[HT40+\]/[HT40${HT40_DIR}]}
+        HT_CAPAB=${HT_CAPAB//\[HT40-\]/[HT40${HT40_DIR}]}
+    else
+        # a 40MHz capability on a 20MHz channel makes hostapd refuse to start
+        HT_CAPAB=${HT_CAPAB//\[HT40+\]/}
+        HT_CAPAB=${HT_CAPAB//\[HT40-\]/}
+    fi
+fi
+
 if [[ $IEEE80211N -eq 1 ]]; then
     cat << EOF >> $CONFDIR/hostapd.conf
 ieee80211n=1
@@ -1874,6 +1962,26 @@ fi
 
 if [[ $IEEE80211AC -eq 1 ]]; then
     echo "ieee80211ac=1" >> $CONFDIR/hostapd.conf
+
+    if [[ $FREQ_BAND == 5 ]]; then
+        case $EFFECTIVE_BW in
+            160) VHT_OPER_CHWIDTH=2 ;;
+            80)  VHT_OPER_CHWIDTH=1 ;;
+            *)   VHT_OPER_CHWIDTH=0 ;;
+        esac
+        echo "vht_oper_chwidth=${VHT_OPER_CHWIDTH}" >> $CONFDIR/hostapd.conf
+
+        if [[ $VHT_OPER_CHWIDTH -ne 0 ]]; then
+            VHT_SEG0=$(get_vht_seg0_idx ${CHANNEL} ${EFFECTIVE_BW})
+            if [[ -n "$VHT_SEG0" ]]; then
+                echo "vht_oper_centr_freq_seg0_idx=${VHT_SEG0}" >> $CONFDIR/hostapd.conf
+            else
+                # no known centre index for this channel, stay narrow rather
+                # than emit a width hostapd can not place
+                sed -i 's/^vht_oper_chwidth=.*/vht_oper_chwidth=0/' $CONFDIR/hostapd.conf
+            fi
+        fi
+    fi
 fi
 
 if [[ $IEEE80211AX -eq 1 ]]; then

--- a/src/ui/glade/wifih.ui
+++ b/src/ui/glade/wifih.ui
@@ -871,6 +871,47 @@
                 <property name="position">2</property>
               </packing>
             </child>
+            <child>
+              <object class="GtkExpander" id="expander_log">
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="margin-left">5</property>
+                <property name="margin-right">5</property>
+                <property name="margin-top">2</property>
+                <child>
+                  <object class="GtkScrolledWindow" id="scroll_log">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="min-content-height">160</property>
+                    <property name="shadow-type">in</property>
+                    <child>
+                      <object class="GtkTextView" id="textview_log">
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="editable">False</property>
+                        <property name="cursor-visible">False</property>
+                        <property name="monospace">True</property>
+                        <property name="wrap-mode">word-char</property>
+                        <property name="left-margin">4</property>
+                        <property name="right-margin">4</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child type="label">
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="label" translatable="yes">Log</property>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">3</property>
+              </packing>
+            </child>
           </object>
           <packing>
             <property name="expand">False</property>

--- a/src/ui/h_prop.c
+++ b/src/ui/h_prop.c
@@ -154,13 +154,22 @@ const char *build_wh_start_command(char *iface_src, char *iface_dest, char *ssid
 }
 
 
+/* create_ap only accepts "2.4" and "5" for --freq-band. Anything else - most
+   importantly the "default" that the config file stores when no band was
+   requested - has to be left off the command line entirely, otherwise
+   create_ap treats it as an explicit band request and refuses to follow the
+   channel the adapter is already associated with. */
+int is_explicit_freq_band(const char *freq){
+    return freq != NULL && (strcmp(freq, "2.4") == 0 || strcmp(freq, "5") == 0);
+}
+
 const char *build_wh_mkconfig_command(ConfigValues* cv){
 
     const char* config_ffile_name=get_config_file(CONFIG_FILE_NAME);
 
     snprintf(cmd_mkconfig, BUFSIZE, "%s %s %s %s '%s' '%s' %s %s",SUDO, CREATE_AP, cv->iface_wifi, cv->iface_inet, cv->ssid, cv->pass,MKCONFIG,config_ffile_name);
 
-    if(cv->freq!=NULL){
+    if(is_explicit_freq_band(cv->freq)){
         strcat(cmd_mkconfig," --freq-band ");
         strcat(cmd_mkconfig,cv->freq);
     }

--- a/src/ui/h_prop.h
+++ b/src/ui/h_prop.h
@@ -52,6 +52,8 @@ static int parse_output(const char *);
 const char *build_wh_start_command(char *, char *, char *, char *);
 const char *build_wh_from_config(void);
 
+int is_explicit_freq_band(const char *);
+
 int startShell(const char *);
 
 int write_config(char *);

--- a/src/ui/read_config.cpp
+++ b/src/ui/read_config.cpp
@@ -121,7 +121,9 @@ static void setConfigValues(const char * key, char *value){
         configValues.channel = value;
 
     if( !strcmp ( FREQ_BAND, key ))
-        configValues.freq = value;
+        /* the config file stores "default" when no band was requested; the
+           rest of the GUI encodes that as NULL */
+        configValues.freq = strcmp(value, "default") ? value : NULL;
 
     if( !strcmp ( USE_PSK, key ))
         configValues.use_psk = value;

--- a/src/ui/ui.c
+++ b/src/ui/ui.c
@@ -800,7 +800,7 @@ static void *run_create_hp_shell(void *cmd) {
 
     /* create_ap reports every failure on stderr, so fold it into the pipe -
        without it a failed start leaves the user with no reason at all */
-    if(configValues.freq)
+    if(is_explicit_freq_band(configValues.freq))
         snprintf(cmd_line, CMD_BUFSIZE, "{ %s --freq-band %s ; } 2>&1", (char*)cmd, configValues.freq);
     else
         snprintf(cmd_line, CMD_BUFSIZE, "{ %s ; } 2>&1", (char*)cmd);

--- a/src/ui/ui.c
+++ b/src/ui/ui.c
@@ -107,6 +107,8 @@ GtkCheckButton *cb_ieee80211ax;
 GtkProgressBar *progress_bar;
 
 GtkLabel *label_status;
+GtkTextView *textview_log;
+GtkExpander *expander_log;
 GtkLabel *label_input_error;
 
 GtkCssProvider* provider;
@@ -169,6 +171,8 @@ static void on_create_hp_clicked(GtkWidget *widget, gpointer data) {
         return;
     }
 
+    clear_log();
+    gtk_label_set_label(label_status, "Starting hotspot...");
     g_thread_new("shell_create_hp", run_create_hp_shell, (void*)build_wh_from_config());
 
 
@@ -215,11 +219,67 @@ static void set_error_text(const char * text){
     gtk_label_set_label(label_input_error,text);
 }
 
+/* create_ap's output is read on a worker thread, and GTK may only be touched
+   from the main loop, so every log update is marshalled through g_idle_add(). */
+static gboolean append_log_line_idle(gpointer data){
+    char *line = data;
+    GtkTextBuffer *tb;
+    GtkTextIter end;
+    GtkTextMark *mark;
+
+    if(textview_log == NULL){
+        g_free(line);
+        return G_SOURCE_REMOVE;
+    }
+
+    tb = gtk_text_view_get_buffer(textview_log);
+    gtk_text_buffer_get_end_iter(tb, &end);
+    gtk_text_buffer_insert(tb, &end, line, -1);
+    gtk_text_buffer_insert(tb, &end, "\n", -1);
+
+    /* keep the newest line in view */
+    gtk_text_buffer_get_end_iter(tb, &end);
+    mark = gtk_text_buffer_create_mark(tb, NULL, &end, FALSE);
+    gtk_text_view_scroll_mark_onscreen(textview_log, mark);
+    gtk_text_buffer_delete_mark(tb, mark);
+
+    g_free(line);
+    return G_SOURCE_REMOVE;
+}
+
+void append_log_line(const char *line){
+    if(line == NULL)
+        return;
+    g_idle_add(append_log_line_idle, g_strdup(line));
+}
+
+/* Called from a GTK signal handler, i.e. already on the main loop. Clearing
+   inline rather than through g_idle_add() also guarantees the reset lands
+   before any line the worker thread queues after it. */
+void clear_log(void){
+    if(textview_log != NULL)
+        gtk_text_buffer_set_text(gtk_text_view_get_buffer(textview_log), "", -1);
+}
+
+static gboolean expand_log_idle(gpointer data){
+    (void) data;
+    if(expander_log != NULL)
+        gtk_expander_set_expanded(expander_log, TRUE);
+    return G_SOURCE_REMOVE;
+}
+
+/* Open the log on failure: the one-line error label rarely carries enough to
+   act on, and the reason is always somewhere in the output. */
+static void expand_log(void){
+    g_idle_add(expand_log_idle, NULL);
+}
+
 /* Show whatever create_ap complained about, falling back to a generic hint
    when it died without a recognisable message. */
 static void show_shell_error(const char *fallback){
     const char *err = get_last_shell_error();
     set_error_text(err != NULL ? err : fallback);
+    expand_log();
 }
 
 static void* entry_mac_warn(GtkWidget *widget, gpointer data){
@@ -465,6 +525,8 @@ int initUi(int argc, char *argv[]){
     rb_freq_5 = (GtkRadioButton *) gtk_builder_get_object(builder, "rb_freq_5");
 
     label_status = (GtkLabel *) gtk_builder_get_object(builder, "label_status");
+    textview_log = (GtkTextView *) gtk_builder_get_object(builder, "textview_log");
+    expander_log = (GtkExpander *) gtk_builder_get_object(builder, "expander_log");
     label_input_error = (GtkLabel *) gtk_builder_get_object(builder, "label_input_error");
 
     progress_bar = (GtkProgressBar *) gtk_builder_get_object(builder, "progress_bar");
@@ -821,7 +883,7 @@ static void *run_create_hp_shell(void *cmd) {
     while (fgets(buf, BUFSIZE, fp) != NULL) {
         buf[strcspn(buf, "\n")] = 0;
         printf("%s\n", buf);
-        gtk_label_set_label(label_status,buf);
+        append_log_line(buf);
         record_shell_error_line(buf);
 
         if (!ap_enabled && strstr(buf, AP_ENABLED) != NULL) {

--- a/src/ui/ui.h
+++ b/src/ui/ui.h
@@ -72,6 +72,15 @@ static void set_error_text(const char * text);
 
 static void show_shell_error(const char *fallback);
 
+/* Appends a line to the log view. Marshals onto the main loop internally, so
+   it is safe to call from the worker thread that reads create_ap's output. */
+void append_log_line(const char *line);
+
+/* Main loop only. */
+void clear_log(void);
+
+static void expand_log(void);
+
 gchar* get_accepted_macs();
 
 static void set_connected_devices_label(); // new

--- a/util/iwlwifi-lar-disable/README.md
+++ b/util/iwlwifi-lar-disable/README.md
@@ -1,0 +1,29 @@
+# iwlwifi `lar_disable`
+
+Restores the `lar_disable` module parameter that `iwlwifi` used to ship, so an
+Intel adapter stops claiming a self-managed regulatory domain and the kernel
+regulatory database applies instead. Without this every 5GHz channel stays
+flagged `no IR` and cannot host an access point.
+
+**Read [docs/howto/intel-5ghz-lar.md](../../docs/howto/intel-5ghz-lar.md) first** -
+it explains how to tell whether this is actually your problem, and covers the
+Secure Boot key enrollment that the install step depends on.
+
+```
+./build.sh                    # patch, build and sign against the running kernel
+sudo COUNTRY=XX ./install.sh  # install and enable, XX = your country code
+sudo ./uninstall.sh           # revert
+```
+
+| File | Purpose |
+| --- | --- |
+| `lar_disable.patch` | the driver change, two files under `drivers/net/wireless/intel/iwlwifi/mvm` |
+| `build.sh` | fetches kernel source, applies the patch, builds and signs `iwlmvm.ko` |
+| `install.sh` | installs into `/lib/modules/<ver>/updates/` and writes the modprobe options |
+| `uninstall.sh` | removes both and restores the distribution module |
+
+Build artefacts and the generated signing key live in
+`/var/lib/linux-wifi-hotspot/lar`. The key is never stored in this repository.
+
+This has to be repeated after a kernel upgrade; the enrolled signing key
+persists, so only `build.sh` and `install.sh` need re-running.

--- a/util/iwlwifi-lar-disable/README.md
+++ b/util/iwlwifi-lar-disable/README.md
@@ -9,6 +9,17 @@ flagged `no IR` and cannot host an access point.
 it explains how to tell whether this is actually your problem, and covers the
 Secure Boot key enrollment that the install step depends on.
 
+Only applies to adapters driven by **`iwlmvm`**, which is the sole operating-mode
+module that gates the self-managed regulatory domain behind a LAR test. `iwlmld`
+(Wi-Fi 7) sets the flag unconditionally and `iwldvm` (older Centrino) never sets
+it at all, so neither is helped by this. Check yours with:
+
+```
+lsmod | grep -E '^iwl(dvm|mvm|mld)'
+```
+
+`build.sh` refuses to run on the unsupported ones.
+
 ```
 ./build.sh                    # patch, build and sign against the running kernel
 sudo COUNTRY=XX ./install.sh  # install and enable, XX = your country code

--- a/util/iwlwifi-lar-disable/build.sh
+++ b/util/iwlwifi-lar-disable/build.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+# Build (and, under Secure Boot, sign) an iwlmvm module that understands a
+# lar_disable parameter. See docs/howto/intel-5ghz-lar.md for the background.
+#
+#   ./build.sh                 build against the running kernel
+#   KERNEL_SRC=/path ./build.sh    use an already unpacked kernel tree
+set -euo pipefail
+
+SELF_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+PATCH="$SELF_DIR/lar_disable.patch"
+KVER=$(uname -r)
+STATE_DIR=/var/lib/linux-wifi-hotspot/lar
+WORK_DIR=${WORK_DIR:-/var/tmp/lwh-lar-build}
+BUILD_DIR=/lib/modules/$KVER/build
+IWL_SUBDIR=drivers/net/wireless/intel/iwlwifi
+
+SUDO=
+[[ $EUID -ne 0 ]] && SUDO=sudo
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+say() { echo "==> $*"; }
+
+# mokutil exits non-zero when it cannot read the kernel trusted keyring even
+# though the answer on stdout is correct, so match the text and ignore status.
+secure_boot_on() {
+    local out; out=$(mokutil --sb-state 2>/dev/null || true)
+    [[ "$out" == *"SecureBoot enabled"* ]]
+}
+mok_enrolled() {
+    local out; out=$(mokutil --test-key "$1" 2>/dev/null || true)
+    [[ "$out" == *"is already enrolled"* ]]
+}
+
+
+[[ -f "$PATCH" ]] || die "missing $PATCH"
+[[ -d "$BUILD_DIR" ]] || die "no kernel build tree at $BUILD_DIR - install the headers for $KVER
+       Debian/Ubuntu: apt install linux-headers-$KVER
+       Arch:          pacman -S linux-headers
+       Fedora:        dnf install kernel-devel-$KVER"
+
+if ! lsmod | grep -q '^iwlmvm'; then
+    echo "WARN: iwlmvm is not loaded - this patch only applies to Intel iwlwifi adapters" >&2
+fi
+
+# ---------------------------------------------------------------- kernel source
+if [[ -n "${KERNEL_SRC:-}" ]]; then
+    SRC_ROOT=$KERNEL_SRC
+    [[ -d "$SRC_ROOT/$IWL_SUBDIR" ]] || die "$SRC_ROOT does not contain $IWL_SUBDIR"
+    say "using kernel source at $SRC_ROOT"
+else
+    mkdir -p "$WORK_DIR"
+    TARBALL=$(ls /usr/src/linux-source-*.tar.* 2>/dev/null | head -1 || true)
+    if [[ -z "$TARBALL" ]]; then
+        if command -v apt-get >/dev/null; then
+            PKG="linux-source-$(echo "$KVER" | cut -d- -f1)"
+            say "installing $PKG"
+            $SUDO apt-get install -y "$PKG" || die "could not install $PKG"
+            TARBALL=$(ls /usr/src/linux-source-*.tar.* 2>/dev/null | head -1 || true)
+        fi
+    fi
+    [[ -n "$TARBALL" ]] || die "no kernel source found.
+       Install your distribution's kernel source package, then re-run, or point
+       this script at an unpacked tree:  KERNEL_SRC=/path/to/linux ./build.sh"
+
+    say "unpacking $IWL_SUBDIR from $TARBALL"
+    ( cd "$WORK_DIR" && tar -xf "$TARBALL" --wildcards "*/$IWL_SUBDIR/*" )
+    SRC_ROOT=$(find "$WORK_DIR" -maxdepth 1 -mindepth 1 -type d | head -1)
+    [[ -d "$SRC_ROOT/$IWL_SUBDIR" ]] || die "unexpected layout in $TARBALL"
+fi
+
+# ---------------------------------------------------------------------- patch
+say "applying lar_disable.patch"
+if patch -p1 -d "$SRC_ROOT" -N --dry-run < "$PATCH" >/dev/null 2>&1; then
+    patch -p1 -d "$SRC_ROOT" -N < "$PATCH"
+elif patch -p1 -d "$SRC_ROOT" -R --dry-run < "$PATCH" >/dev/null 2>&1; then
+    say "already applied, continuing"
+else
+    die "lar_disable.patch does not apply to this kernel source.
+       The upstream function may have changed; apply it by hand and re-run with
+       KERNEL_SRC=$SRC_ROOT"
+fi
+
+# ---------------------------------------------------------------------- build
+say "building iwlmvm for $KVER (this takes a few minutes)"
+make -C "$BUILD_DIR" M="$SRC_ROOT/$IWL_SUBDIR" modules -j"$(nproc)"
+
+MODULE="$SRC_ROOT/$IWL_SUBDIR/mvm/iwlmvm.ko"
+[[ -f "$MODULE" ]] || die "build produced no $MODULE"
+modinfo "$MODULE" | grep -q 'lar_disable' || die "built module has no lar_disable parameter"
+
+$SUDO mkdir -p "$STATE_DIR"
+$SUDO cp "$MODULE" "$STATE_DIR/iwlmvm.ko"
+
+# ----------------------------------------------------------------------- sign
+if secure_boot_on; then
+    say "Secure Boot is enabled - signing the module"
+    SIGN_FILE="$BUILD_DIR/scripts/sign-file"
+    [[ -x "$SIGN_FILE" ]] || die "no sign-file helper at $SIGN_FILE"
+
+    if ! $SUDO test -f "$STATE_DIR/MOK.priv"; then
+        say "generating a machine owner key in $STATE_DIR"
+        $SUDO openssl req -new -x509 -newkey rsa:2048 -nodes -days 36500 \
+            -keyout "$STATE_DIR/MOK.priv" -outform DER -out "$STATE_DIR/MOK.der" \
+            -subj "/CN=linux-wifi-hotspot iwlwifi lar_disable/"
+        $SUDO chmod 600 "$STATE_DIR/MOK.priv"
+    fi
+
+    $SUDO "$SIGN_FILE" sha256 "$STATE_DIR/MOK.priv" "$STATE_DIR/MOK.der" "$STATE_DIR/iwlmvm.ko"
+    say "signed"
+
+    if ! mok_enrolled "$STATE_DIR/MOK.der"; then
+        cat <<EOF
+
+The signing key is not enrolled yet. Enroll it before installing:
+
+    sudo mokutil --import $STATE_DIR/MOK.der
+
+Choose a one-time password, reboot, and complete the blue "MOK Manager"
+screen: press a key at the countdown, then Enroll MOK -> Continue -> Yes ->
+your password -> Reboot. Letting the countdown expire discards the request.
+
+Then run:  sudo $SELF_DIR/install.sh
+EOF
+        exit 0
+    fi
+else
+    say "Secure Boot is disabled - no signature needed"
+fi
+
+echo
+say "Done. Install with:  sudo $SELF_DIR/install.sh"

--- a/util/iwlwifi-lar-disable/build.sh
+++ b/util/iwlwifi-lar-disable/build.sh
@@ -38,8 +38,31 @@ mok_enrolled() {
        Arch:          pacman -S linux-headers
        Fedora:        dnf install kernel-devel-$KVER"
 
-if ! lsmod | grep -q '^iwlmvm'; then
-    echo "WARN: iwlmvm is not loaded - this patch only applies to Intel iwlwifi adapters" >&2
+# Only iwlmvm gates REGULATORY_WIPHY_SELF_MANAGED behind a LAR test, so it is
+# the only operating-mode module this patch can hook into. Fail early rather
+# than build a module the machine will never use. FORCE=1 to build anyway, e.g.
+# when preparing a module for a different machine.
+# grep -q exits on the first match, which SIGPIPEs the writer; under pipefail
+# that makes a successful match look like a failed pipeline. Read once instead.
+LSMOD=$(lsmod 2>/dev/null || true)
+module_loaded() { grep -q "^$1 " <<<"$LSMOD"; }
+
+if [[ "${FORCE:-0}" != "1" ]]; then
+    if module_loaded iwlmld; then
+        die "this machine uses the iwlmld driver (Wi-Fi 7 parts).
+       iwl_mld_hw_set_regulatory() sets REGULATORY_WIPHY_SELF_MANAGED
+       unconditionally, so there is no LAR test for lar_disable to switch off
+       and this patch cannot help. See docs/howto/intel-5ghz-lar.md."
+    elif module_loaded iwldvm; then
+        die "this machine uses the iwldvm driver (older Centrino parts).
+       Those never claim a self-managed regulatory domain, so the NO_IR problem
+       this patch addresses does not apply. See docs/howto/intel-5ghz-lar.md."
+    elif ! module_loaded iwlmvm; then
+        die "iwlmvm is not loaded - this patch only applies to Intel iwlwifi
+       adapters handled by the mvm operating mode. Check with:
+           lsmod | grep -E '^iwl(dvm|mvm|mld)'
+       Set FORCE=1 to build anyway."
+    fi
 fi
 
 # ---------------------------------------------------------------- kernel source
@@ -64,7 +87,7 @@ else
 
     say "unpacking $IWL_SUBDIR from $TARBALL"
     ( cd "$WORK_DIR" && tar -xf "$TARBALL" --wildcards "*/$IWL_SUBDIR/*" )
-    SRC_ROOT=$(find "$WORK_DIR" -maxdepth 1 -mindepth 1 -type d | head -1)
+    SRC_ROOT=$(find "$WORK_DIR" -maxdepth 1 -mindepth 1 -type d | head -1 || true)
     [[ -d "$SRC_ROOT/$IWL_SUBDIR" ]] || die "unexpected layout in $TARBALL"
 fi
 
@@ -86,7 +109,8 @@ make -C "$BUILD_DIR" M="$SRC_ROOT/$IWL_SUBDIR" modules -j"$(nproc)"
 
 MODULE="$SRC_ROOT/$IWL_SUBDIR/mvm/iwlmvm.ko"
 [[ -f "$MODULE" ]] || die "build produced no $MODULE"
-modinfo "$MODULE" | grep -q 'lar_disable' || die "built module has no lar_disable parameter"
+MODINFO_OUT=$(modinfo "$MODULE" 2>/dev/null || true)
+[[ "$MODINFO_OUT" == *lar_disable* ]] || die "built module has no lar_disable parameter"
 
 $SUDO mkdir -p "$STATE_DIR"
 $SUDO cp "$MODULE" "$STATE_DIR/iwlmvm.ko"

--- a/util/iwlwifi-lar-disable/install.sh
+++ b/util/iwlwifi-lar-disable/install.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# Install the module built by build.sh and turn lar_disable on.
+#
+#   sudo ./install.sh              install, leave the regulatory country alone
+#   sudo COUNTRY=LK ./install.sh   also pin the regulatory country
+set -euo pipefail
+
+KVER=$(uname -r)
+STATE_DIR=/var/lib/linux-wifi-hotspot/lar
+MODULE=$STATE_DIR/iwlmvm.ko
+
+SUDO=
+[[ $EUID -ne 0 ]] && SUDO=sudo
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+say() { echo "==> $*"; }
+
+# mokutil exits non-zero when it cannot read the kernel trusted keyring even
+# though the answer on stdout is correct, so match the text and ignore status.
+secure_boot_on() {
+    local out; out=$(mokutil --sb-state 2>/dev/null || true)
+    [[ "$out" == *"SecureBoot enabled"* ]]
+}
+mok_enrolled() {
+    local out; out=$(mokutil --test-key "$1" 2>/dev/null || true)
+    [[ "$out" == *"is already enrolled"* ]]
+}
+
+
+[[ -f "$MODULE" ]] || die "no module at $MODULE - run build.sh first"
+
+# Refuse rather than leave an unloadable module in the boot path: under Secure
+# Boot an unenrolled signature means no WiFi at all after the next reboot.
+if secure_boot_on; then
+    if ! mok_enrolled "$STATE_DIR/MOK.der"; then
+        die "Secure Boot is on and $STATE_DIR/MOK.der is not enrolled.
+       Run:  sudo mokutil --import $STATE_DIR/MOK.der
+       then reboot and complete the MOK Manager screen."
+    fi
+fi
+
+say "installing iwlmvm.ko into /lib/modules/$KVER/updates/"
+$SUDO install -D -m644 "$MODULE" "/lib/modules/$KVER/updates/iwlmvm.ko"
+$SUDO depmod -a
+
+say "enabling lar_disable"
+printf 'options iwlmvm lar_disable=1\n' |
+    $SUDO tee /etc/modprobe.d/iwlmvm-lar-disable.conf >/dev/null
+
+if [[ -n "${COUNTRY:-}" ]]; then
+    say "pinning regulatory country to $COUNTRY"
+    printf 'options cfg80211 ieee80211_regdom=%s\n' "$COUNTRY" |
+        $SUDO tee /etc/modprobe.d/cfg80211-regdom.conf >/dev/null
+else
+    cat <<'EOF'
+
+NOTE: no COUNTRY was given. Without a regulatory country the adapter falls back
+      to the world domain ("country 00"), where every 5GHz channel is still
+      flagged "no IR" and cannot host an AP. Either re-run with
+      COUNTRY=<your two letter code>, or rely on your router's Country IE.
+EOF
+fi
+
+cat <<EOF
+
+Done. Reboot, then check:
+
+    iw reg get | head -3
+
+The per-phy "(self-managed)" block should be gone and the country should be
+yours. Confirm the 5GHz channels lost their "no IR" flag with:
+
+    iw phy \$(iw dev | awk '/^phy#/{gsub("#","");print \$1;exit}') info | grep '5[0-9]\{3\}\.0 MHz'
+
+Revert at any time with:  sudo $(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/uninstall.sh
+EOF

--- a/util/iwlwifi-lar-disable/lar_disable.patch
+++ b/util/iwlwifi-lar-disable/lar_disable.patch
@@ -1,0 +1,42 @@
+--- a/drivers/net/wireless/intel/iwlwifi/mvm/mvm.h
++++ b/drivers/net/wireless/intel/iwlwifi/mvm/mvm.h
+@@ -85,9 +85,11 @@
+ /**
+  * struct iwl_mvm_mod_params - module parameters for iwlmvm
+  * @power_scheme: one of enum iwl_power_scheme
++ * @lar_disable: disable LAR (Location Aware Regulatory)
+  */
+ struct iwl_mvm_mod_params {
+ 	int power_scheme;
++	bool lar_disable;
+ };
+ extern struct iwl_mvm_mod_params iwlmvm_mod_params;
+ 
+@@ -1436,6 +1438,15 @@
+ 				   IWL_UCODE_TLV_CAPA_LAR_SUPPORT);
+ 
+ 	/*
++	 * With LAR the regulatory domain is owned by the firmware and the wiphy
++	 * becomes self-managed, which leaves every 5GHz channel flagged NO_IR
++	 * while the firmware sits on the world domain. Allow the user to opt
++	 * out so the kernel regulatory database applies instead.
++	 */
++	if (iwlmvm_mod_params.lar_disable)
++		return false;
++
++	/*
+ 	 * Enable LAR only if it is supported by the FW (TLV) &&
+ 	 * enabled in the NVM
+ 	 */
+--- a/drivers/net/wireless/intel/iwlwifi/mvm/ops.c
++++ b/drivers/net/wireless/intel/iwlwifi/mvm/ops.c
+@@ -47,6 +47,9 @@
+ MODULE_PARM_DESC(power_scheme,
+ 		 "power management scheme: 1-active, 2-balanced, 3-low power, default: 2");
+ 
++module_param_named(lar_disable, iwlmvm_mod_params.lar_disable, bool, 0444);
++MODULE_PARM_DESC(lar_disable, "disable LAR (Location Aware Regulatory), default: false");
++
+ /*
+  * module init and exit functions
+  */

--- a/util/iwlwifi-lar-disable/uninstall.sh
+++ b/util/iwlwifi-lar-disable/uninstall.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Undo install.sh and go back to the distribution iwlmvm.
+set -euo pipefail
+KVER=$(uname -r)
+SUDO=
+[[ $EUID -ne 0 ]] && SUDO=sudo
+
+$SUDO rm -f "/lib/modules/$KVER/updates/iwlmvm.ko"
+$SUDO rm -f /etc/modprobe.d/iwlmvm-lar-disable.conf
+$SUDO rm -f /etc/modprobe.d/cfg80211-regdom.conf
+$SUDO depmod -a
+echo "==> Reverted. Reboot to load the distribution module again."
+echo "    Build artefacts and the signing key are kept in /var/lib/linux-wifi-hotspot/lar"


### PR DESCRIPTION
Makes 5GHz hotspots work on the hardware people actually report problems with, and fixes the channel and band selection bugs that made even 2.4GHz fail once the adapter was associated to a network.

Four independent problems, verified on an Intel AX201 (`iwlwifi`, Linux 7.0) with an AP running concurrently with a 5GHz client connection.

---

## 1. `create_ap`: channel selection on single-channel AP adapters

Since Linux 6.11 `iwlwifi` only advertises AP mode in a single-channel interface combination (kernel commit `5c38bedac16a`):

```
* #{ managed } <= 1, #{ P2P-client, P2P-GO } <= 1, #{ P2P-device } <= 1, total <= 3, #channels <= 2
* #{ managed } <= 1, #{ AP, P2P-client, P2P-GO } <= 1, #{ P2P-device } <= 1, total <= 3, #channels <= 1
```

Only the second permits an AP, and it is limited to one channel — so the AP must share the station's channel.

**The capability probe matched the wrong combination.** It grepped the whole block for `#channels <= 2`, which matches the *first* line above — the one with no `AP`. `create_ap` concluded "multiple channels supported", skipped the fallback, and hostapd failed with `Failed to set beacon parameters`. Now handled by `get_ap_max_channels()`, which reassembles each (line-wrapped) combination record and reads `#channels` only from those containing `AP`.

**`--freq-band` bypassed the same-channel handling entirely**, so an explicit band walked straight into the same failure. The constraint now applies there too, and an impossible request gets an explanation instead of hostapd's message:

```
ERROR: Your adapter can only run an access point on the channel it is already
       connected to, but a different channel was requested.

           requested: channel 36 (5GHz)
           connected: channel 5 (2.4GHz) on wlp0s20f3
```

**`FREQ_BAND=default` was never normalised.** `--mkconfig` and the GUI write it; the literal string matched neither `2.4` nor `5`, fell through every comparison, and silently put the hotspot on 5GHz channel 36.

**Empty fallback channel when disconnected** — `WIFI_IFACE_CHANNEL` is only set while associated and was compared arithmetically, so empty evaluated as `0`:

```
Falling back to channel
ERROR: Your adapter can not transmit to channel , frequency band 5GHz.
```

Adapters whose phy is self-managed and still on `country 00` also now get an explanation of why 5GHz is unusable, rather than just being told the channel does not work.

## 2. GUI: `--freq-band default`

`read_config` passed the config file's literal `FREQ_BAND=default` through as `configValues.freq`. Everywhere else in the GUI "no band requested" is `NULL`, so both command builders appended it verbatim:

```
create_ap --config /etc/create_ap.conf --freq-band default
```

`create_ap` treats any `--freq-band` as an explicit request, so this pinned the hotspot to the 2.4GHz default instead of following the station's channel — a 2.4GHz hotspot when 5GHz was available, or an outright failure. Normalised to `NULL` at the source and gated both builders on `is_explicit_freq_band()`. This also restores channel-range validation for the auto case, which previously validated nothing.

## 3. `create_ap`: VHT channel width

`--ieee80211ac` only ever emitted `ieee80211ac=1`. hostapd defaults `vht_oper_chwidth` to 0, so the AP stayed at 20/40MHz and 80MHz was unreachable. Now emits `vht_oper_chwidth` and `vht_oper_centr_freq_seg0_idx`, with a new `--vht-chwidth` (20/40/80/160, default 80) capped to what the regulatory domain allows so an over-wide request degrades instead of failing to start.

Also fixes the HT40 secondary-channel direction, which was hardcoded `[HT40+]` — only correct for the lower channel of each 40MHz pair, so on 153, 161, 40, 48 it silently cost half the width.

## 4. Docs: 5GHz on Intel adapters

The most-reported 5GHz failure is not a `create_ap` bug at all. Intel cards using LAR keep the regulatory domain in firmware and mark the wiphy self-managed; on the world domain every 5GHz channel is flagged `NO_IR`, which forbids beaconing. The card can join a 5GHz network but never host on one.

`iw reg set` cannot help — a self-managed wiphy ignores it. The kernel's `IR-CONCURRENT` relaxation cannot either, twice over: `CONFIG_CFG80211_REG_RELAX_NO_IR` depends on `CFG80211_CERTIFICATION_ONUS`, which distributions do not enable, and `cfg80211_ir_permissive_chan()` excludes `NL80211_IFTYPE_AP` regardless of that.

Adds [`docs/howto/intel-5ghz-lar.md`](docs/howto/intel-5ghz-lar.md) — how to tell this apart from the single-channel restriction, why it happens, what to do — and [`util/iwlwifi-lar-disable/`](util/iwlwifi-lar-disable), a patch restoring the removed `iwlwifi` `lar_disable` parameter plus scripts to build, sign, install and revert it. The scripts handle the Secure Boot path, where this is easiest to get wrong: `install.sh` refuses to run until the signing key is enrolled, so there is never a boot with an unloadable WiFi module. No key material is stored in the repo.

The fix is narrower than the diagnosis, and the guide says so up front. `iwlwifi` hands the card to one of three operating-mode modules and they differ:

| Module | Behaviour | Covered |
| --- | --- | --- |
| `iwlmvm` | sets `REGULATORY_WIPHY_SELF_MANAGED` only when `iwl_mvm_is_lar_supported()` | yes — that test is what the patch hooks into |
| `iwlmld` | sets it unconditionally in `iwl_mld_hw_set_regulatory()` | no — nothing for `lar_disable` to switch off |
| `iwldvm` | uses `REGULATORY_CUSTOM_REG`, never self-managed | not affected by this failure at all |

`build.sh` refuses to run on the two unsupported modules rather than build something the machine can never use (`FORCE=1` overrides, for cross-building).


## 5. GUI: show the whole log, not just the last line

The status label was overwritten with every line `create_ap` produced, so once a run finished only the last line survived — on failure usually the trailing cleanup message rather than the error itself.

Adds a collapsible **Log** expander with a scrollable, read-only monospace view under the status area. Every line goes there; the label goes back to carrying only the running state (`Starting hotspot...` → `Running as PID: N` / `Not running`). The log clears when a run starts and opens itself when a run fails.

Output is read on a worker thread and GTK may only be touched from the main loop, so appends are marshalled with `g_idle_add()`. Clearing stays synchronous — its only caller is a signal handler already on the main loop, and inline clearing keeps the reset ordered ahead of anything the worker queues after it.

---

## Testing

Verified end to end on an AX201. With `lar_disable=1` the wiphy stops being self-managed, `no IR` disappears from every 5GHz channel, and:

```
wlp0s20f3 is already associated with channel 149 (5745.0 MHz)
Adapter supports the AP on one channel only, following wlp0s20f3 to channel 149
Transmitting to channel 149...
ap0: AP-ENABLED
```

Confirmed by hostapd itself (`state=ENABLED freq=5745 channel=149`), by the kernel (`iw dev ap0 info` → `channel 149 (5745 MHz)`), and from a client device, with the uplink still connected. `dnsmasq` and the `MASQUERADE` rule both present; clean teardown.

Channel/band matrix, station associated on channel 5:

| Scenario | Before | After |
| --- | --- | --- |
| defaults (`FREQ_BAND=default`) | tried 5GHz ch36 → fail | follows to ch5, `AP-ENABLED` |
| `--freq-band 2.4` | `Failed to set beacon parameters` | follows to ch5, `AP-ENABLED` |
| `--freq-band 5` | `Failed to set beacon parameters` | clear error, exits |
| `-c 11` | `Failed to set beacon parameters` | clear error, exits |
| `--freq-band 5`, disconnected | `can not transmit to channel ` (empty) | `channel 36` + regdomain explanation |
| defaults, disconnected | worked | worked, `AP-ENABLED` on ch1 |

VHT width, across regulatory limits:

```
ch=149 reg=80  want=80  ac=1 -> [HT40+]  chwidth=1 seg0=155
ch=153 reg=80  want=80  ac=1 -> [HT40-]  chwidth=1 seg0=155   (direction corrected)
ch=36  reg=80  want=160 ac=1 -> [HT40+]  chwidth=1 seg0=42    (capped 160 -> 80)
ch=36  reg=160 want=160 ac=1 -> [HT40+]  chwidth=2 seg0=50
ch=149 reg=80  want=80  ac=0 -> [HT40+]  (no VHT, 11n caps at 40)
ch=149 reg=20  want=80  ac=1 -> HT40 dropped, chwidth=0
```

Behaviour on multi-channel-capable adapters is unchanged: when a combination containing `AP` allows more than one channel, the station's band is followed only if no band was explicitly requested.

---

Fixes #435
Fixes #472
Fixes #344
Fixes #206

Should also cover these, but the reports lack the detail to close them automatically — worth asking the reporters to retest: #281, #448, #452, #487, #495, #509, #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)


