### PR TITLE
create_ap: ask firewalld for the hotspot's DHCP, DNS and NAT

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ If you only need the command line without GUI run `make install-cli-only` as the
 
 - If any problems with **RealTeK Wifi Adapters** see [this](docs/howto/realtek.md)
 
-- **Unable to allocate IP: firewalld issue:** Please check for potential fixes: [#209](https://github.com/lakinduakash/linux-wifi-hotspot/issues/209) [#166](https://github.com/lakinduakash/linux-wifi-hotspot/issues/166)
+- **Unable to allocate IP: firewalld issue:** firewalld keeps its own ruleset, which drops the hotspot's DHCP and DNS traffic no matter what `create_ap` adds with `iptables`, so clients associate but never get an address. `create_ap` now puts the AP interface in firewalld's `nm-shared` zone and enables masquerading on the uplink's zone for as long as the hotspot runs, the same way NetworkManager handles a shared connection. If you are on an older release, or want to do it by hand, see [#209](https://github.com/lakinduakash/linux-wifi-hotspot/issues/209) [#166](https://github.com/lakinduakash/linux-wifi-hotspot/issues/166)
 
 - **Clients see the hotspot but cannot connect:** if devices keep associating and disconnecting, your adapter's firmware may not support AP mode with encryption. `create_ap` now warns when it detects this. Broadcom adapters in T2 Macs are known to be affected, and no `create_ap` option works around it - a USB WiFi adapter is needed. See [#525](https://github.com/lakinduakash/linux-wifi-hotspot/pull/525).
 

--- a/src/scripts/create_ap
+++ b/src/scripts/create_ap
@@ -820,6 +820,10 @@ ROUTE_ADDRS=
 
 HAVEGED_WATCHDOG_PID=
 
+FIREWALLD_AP_ZONE=
+FIREWALLD_AP_OLD_ZONE=
+FIREWALLD_MASQ_ZONE=
+
 _cleanup() {
     local PID x
 
@@ -876,6 +880,8 @@ _cleanup() {
 
         rm -rf $COMMON_CONFDIR
     fi
+
+    firewalld_down
 
     if [[ "$SHARE_METHOD" != "none" ]]; then
         if [[ "$SHARE_METHOD" == "nat" ]]; then
@@ -978,6 +984,82 @@ clean_exit() {
     [[ $BASHPID -ne $$ ]] && kill -USR1 $$
     # we don't need to call cleanup because it's traped on EXIT
     exit 0
+}
+
+# firewalld keeps its own nftables ruleset, and it is evaluated regardless of
+# the rules create_ap inserts with iptables. The hotspot's DHCP and DNS
+# requests are dropped there, so clients associate, never get a lease and
+# give up - the long-standing complaint in #166 and #209.
+#
+# Rather than fight it, ask firewalld for what we need, the way
+# NetworkManager does for its own shared connections: put the AP interface in
+# the nm-shared zone, which firewalld ships for exactly this purpose (target
+# ACCEPT, services dhcp and dns, icmp), and turn on masquerading for the zone
+# the uplink is in. Everything is runtime only - no --permanent - so nothing
+# outlives the hotspot, and cleanup puts the interface back where it was.
+
+firewalld_is_running() {
+    which firewall-cmd > /dev/null 2>&1 || return 1
+    firewall-cmd --state > /dev/null 2>&1
+}
+
+# the zone an interface is in, or the default zone if it is in none
+firewalld_zone_of() {
+    local zone
+    zone=$(firewall-cmd --get-zone-of-interface="$1" 2> /dev/null)
+    [[ -z "$zone" || "$zone" == "no zone" ]] && zone=$(firewall-cmd --get-default-zone 2> /dev/null)
+    echo "$zone"
+}
+
+firewalld_up() {
+    local ap_iface="$1" uplink="$2" zone
+
+    # nm-shared is the zone meant for a shared connection; older firewalld
+    # releases do not have it, so fall back to trusted
+    for zone in nm-shared trusted; do
+        firewall-cmd --info-zone="$zone" > /dev/null 2>&1 && break
+    done
+
+    FIREWALLD_AP_OLD_ZONE=$(firewall-cmd --get-zone-of-interface="$ap_iface" 2> /dev/null)
+    [[ "$FIREWALLD_AP_OLD_ZONE" == "no zone" ]] && FIREWALLD_AP_OLD_ZONE=
+
+    if firewall-cmd -q --zone="$zone" --change-interface="$ap_iface" 2> /dev/null; then
+        FIREWALLD_AP_ZONE=$zone
+        echo "firewalld is running; $ap_iface put in its $zone zone"
+    else
+        echo "WARN: firewalld is running but $ap_iface could not be put in a zone." >&2
+        echo "      Clients may associate without ever getting an IP address. See" >&2
+        echo "      https://github.com/lakinduakash/linux-wifi-hotspot/issues/166" >&2
+        return
+    fi
+
+    [[ "$SHARE_METHOD" != "nat" ]] && return
+
+    # only touch masquerading if it is off, so cleanup never disables it on a
+    # system that had it enabled all along
+    zone=$(firewalld_zone_of "$uplink")
+    if [[ -n "$zone" ]] && ! firewall-cmd -q --zone="$zone" --query-masquerade; then
+        if firewall-cmd -q --zone="$zone" --add-masquerade; then
+            FIREWALLD_MASQ_ZONE=$zone
+            echo "firewalld: masquerading enabled on zone $zone for $uplink"
+        fi
+    fi
+}
+
+firewalld_down() {
+    firewalld_is_running || return 0
+
+    if [[ -n "$FIREWALLD_AP_ZONE" ]]; then
+        if [[ -n "$FIREWALLD_AP_OLD_ZONE" ]]; then
+            firewall-cmd -q --zone="$FIREWALLD_AP_OLD_ZONE" --change-interface="$WIFI_IFACE"
+        else
+            firewall-cmd -q --zone="$FIREWALLD_AP_ZONE" --remove-interface="$WIFI_IFACE"
+        fi
+    fi
+
+    [[ -n "$FIREWALLD_MASQ_ZONE" ]] && firewall-cmd -q --zone="$FIREWALLD_MASQ_ZONE" --remove-masquerade
+
+    return 0
 }
 
 list_running_conf() {
@@ -2177,6 +2259,12 @@ if [[ "$SHARE_METHOD" != "none" ]]; then
     fi
 else
     echo "No Internet sharing"
+fi
+
+# firewalld drops the hotspot's DHCP and DNS traffic unless the AP interface
+# is in a zone that permits it, whatever iptables says. See issue #166.
+if [[ "$SHARE_METHOD" != "bridge" ]] && firewalld_is_running; then
+    firewalld_up "$WIFI_IFACE" "$INTERNET_IFACE"
 fi
 
 # start dhcp + dns (optional)


### PR DESCRIPTION
Fixes #166 — with firewalld running, clients associate to the hotspot but never get an IP address.

### The problem

firewalld keeps its own nftables ruleset, and it is evaluated regardless of what `create_ap` inserts with `iptables`. The `-I INPUT ... --dport 67 -j ACCEPT` and DNS rules land in a different table, so the hotspot's DHCP and DNS requests are dropped anyway: the client associates, completes the WPA handshake, waits for a lease that never comes, and drops the connection.

That is #166, open since 2021 and labelled `help wanted`, and it is also what #209 was about. The thread has collected several manual workarounds over the years — `--add-service=dhcp/dns` plus `--add-masquerade`, `--direct` rules, a hand-built `hotspot` zone with a forwarding policy — but nothing in the script, so every user hits it and has to find the issue first.

### The change

Ask firewalld for what the hotspot needs, the way NetworkManager already does for its own shared connections.

When `firewall-cmd --state` reports firewalld running and the sharing method is not `bridge`:

1. The AP interface is put in the **`nm-shared`** zone — firewalld ships it for exactly this case (`target: ACCEPT`, services `dhcp` and `dns`, `icmp`/`ipv6-icmp`). Releases that predate it fall back to `trusted`.
2. When sharing by NAT, **masquerading is enabled on the zone the uplink interface is in** (its own zone if it has one, otherwise the default zone).

Cleanup puts it back: the AP interface returns to the zone it came from, or is removed from the zone if it had none, and masquerading is switched off **only if this run switched it on** — a system that had it enabled all along keeps it.

Everything is runtime only. No `--permanent`, so nothing outlives the hotspot and a `firewall-cmd --reload` returns the machine to its configured state. If firewalld is not installed or not running, not a single command runs and behaviour is exactly as before.

If the interface cannot be put in a zone, the run continues with a warning pointing at #166 rather than failing — the hotspot itself still comes up.

### Why this shape

- **`nm-shared` over a hand-built zone.** It already exists, it is what NetworkManager's own "shared to other computers" mode uses, and it carries precisely the services a hotspot needs. Creating a bespoke zone means naming it, defining its services, managing its lifetime and cleaning it up on crash.
- **Runtime, not `--permanent`.** `create_ap` already restores `ip_forward` and the bridge sysctls at exit; leaving firewall rules behind after the hotspot stops would be a surprise, and several people in #166 were bitten by permanent rules they later had to hunt down.
- **Masquerade is left alone when already on.** Turning it off in cleanup on a machine that shares another connection through the same zone would break that connection.

### Testing

openSUSE Tumbleweed, kernel 6.18.45, firewalld 2.3.2 (nftables backend), NetworkManager, Intel AX201, uplink associated on 2.4GHz channel 6, sharing method `nat`.

This machine also needs #532 for hostapd to start at all, so the runs below are this branch merged with that one. The firewalld behaviour is independent of it.

**Before:** the AP came up, clients associated and completed the WPA handshake, then dropped seconds later, over and over - no DHCP lease. Adding `ap0` to a permissive zone by hand was the only way to get an address, which is what the workarounds in #166 have people doing.

**After**, starting from masquerading switched off so the code path is actually exercised:

```
# firewall-cmd --zone=public --query-masquerade
no

# ./src/scripts/create_ap -c 6 wlo1 wlo1 TestAP '<passphrase>'
Creating a virtual WiFi interface... ap0 created.
Transmitting to channel 6...
Sharing Internet using method: nat
firewalld is running; ap0 put in its nm-shared zone
firewalld: masquerading enabled on zone public for wlo1
ap0: interface state UNINITIALIZED->ENABLED
ap0: AP-ENABLED
ap0: AP-STA-CONNECTED 16:91:1b:04:e8:e9
ap0: EAPOL-4WAY-HS-COMPLETED 16:91:1b:04:e8:e9
```

While it ran - the client gets an address and its traffic is masqueraded out of the uplink:

```
# firewall-cmd --get-zone-of-interface=ap0
nm-shared
# firewall-cmd --zone=public --query-masquerade
yes
# cat /tmp/create_ap.wlo1.conf.*/dnsmasq.leases
1788988273 16:91:1b:04:e8:e9 192.168.12.2 <phone> 01:16:91:1b:04:e8:e9

# grep -c 'src=192.168.12' /proc/net/nf_conntrack
30
# grep 'src=192.168.12' /proc/net/nf_conntrack | head -2
ipv4 2 tcp 6 61 TIME_WAIT src=192.168.12.2 dst=188.41.249.12 sport=40122 dport=8080 \
    src=188.41.249.12 dst=192.168.1.103 sport=8080 dport=40122 [ASSURED]
ipv4 2 tcp 6 23 LAST_ACK src=192.168.12.2 dst=185.60.218.54 sport=59424 dport=443 \
    src=185.60.218.54 dst=192.168.1.103 sport=443 dport=59424 [ASSURED]
```

The reply tuple is rewritten to `192.168.1.103`, the uplink's own address, so the client's traffic really is being translated and answered - browsing worked on the phone.

After `Ctrl+C` nothing is left behind:

```
# firewall-cmd --zone=nm-shared --list-interfaces
                              (empty)
# firewall-cmd --zone=public --query-masquerade
no                            (this run turned it on, this run turned it off)
```

A run where masquerading was already enabled beforehand leaves it enabled at exit, as intended, and prints only the zone line.

### Notes

- Only the `nat` and `none` sharing methods are touched; `bridge` does not need it.
- This adds its helpers at the same spot in `create_ap` as #532, so whichever of the two lands second needs a trivial rebase - happy to do it whenever you want.
- Tested against firewalld 2.3.2. The fallback to `trusted` covers releases without `nm-shared`, but I have not tested one.
